### PR TITLE
Add support for Anthropic Sonnet and Opus 4.0 models

### DIFF
--- a/data/providers/anthropic/model-families/claude-3.7-sonnet/attributes.toml
+++ b/data/providers/anthropic/model-families/claude-3.7-sonnet/attributes.toml
@@ -7,6 +7,6 @@ name-regex = '^claude-3-7-sonnet(-.*)?$'
 supports-computer-use = true
 
 [converser.tokens-limits]
-per-response = 8192 # Extended thinking: 64K / 128K (beta).
+per-response = 64_000
 
 # TODO: Define controls for extended thinking.

--- a/data/providers/anthropic/model-families/claude-opus-4/attributes.toml
+++ b/data/providers/anthropic/model-families/claude-opus-4/attributes.toml
@@ -1,0 +1,12 @@
+format-version = 1
+
+[converser]
+name-regex = '^claude-opus-4(-.*)?$'
+
+[converser.special]
+supports-computer-use = true
+
+[converser.tokens-limits]
+per-response = 8192 # Extended thinking: 64K / 128K (beta).
+
+# TODO: Define controls for extended thinking.

--- a/data/providers/anthropic/model-families/claude-opus-4/attributes.toml
+++ b/data/providers/anthropic/model-families/claude-opus-4/attributes.toml
@@ -7,6 +7,6 @@ name-regex = '^claude-opus-4(-.*)?$'
 supports-computer-use = true
 
 [converser.tokens-limits]
-per-response = 8192 # Extended thinking: 64K / 128K (beta).
+per-response = 32_000
 
 # TODO: Define controls for extended thinking.

--- a/data/providers/anthropic/model-families/claude-sonnet-4/attributes.toml
+++ b/data/providers/anthropic/model-families/claude-sonnet-4/attributes.toml
@@ -1,0 +1,12 @@
+format-version = 1
+
+[converser]
+name-regex = '^claude-sonnet-4(-.*)?$'
+
+[converser.special]
+supports-computer-use = true
+
+[converser.tokens-limits]
+per-response = 8192 # Extended thinking: 64K / 128K (beta).
+
+# TODO: Define controls for extended thinking.

--- a/data/providers/anthropic/model-families/claude-sonnet-4/attributes.toml
+++ b/data/providers/anthropic/model-families/claude-sonnet-4/attributes.toml
@@ -7,6 +7,6 @@ name-regex = '^claude-sonnet-4(-.*)?$'
 supports-computer-use = true
 
 [converser.tokens-limits]
-per-response = 8192 # Extended thinking: 64K / 128K (beta).
+per-response = 64_000
 
 # TODO: Define controls for extended thinking.

--- a/sources/aiwb/providers/clients/anthropic/clients.py
+++ b/sources/aiwb/providers/clients/anthropic/clients.py
@@ -143,6 +143,8 @@ class AnthropicClient( Client, class_decorators = ( __.standard_dataclass, ) ):
             'claude-3-5-haiku-latest',
             'claude-3-5-sonnet-latest',
             'claude-3-7-sonnet-latest',
+            'claude-opus-4-0',
+            'claude-sonnet-4-0',
         )
         results = tuple(
             model.id for model
@@ -185,6 +187,10 @@ _model_names = __.DictionaryProxy( {
         'claude-3-5-sonnet-latest',
         'claude-3-7-sonnet-20250219',
         'claude-3-7-sonnet-latest',
+        'claude-opus-4-0',
+        'claude-opus-4-20250514',
+        'claude-sonnet-4-0',
+        'claude-sonnet-4-20250514',
     ),
     ProviderVariants.AwsBedrock: (
         'anthropic.claude-3-haiku-20240307-v1:0',
@@ -194,6 +200,8 @@ _model_names = __.DictionaryProxy( {
         'anthropic.claude-3-5-sonnet-20240620-v1:0',
         'anthropic.claude-3-5-sonnet-20241022-v2:0',
         'anthropic.claude-3-7-sonnet-20250219-v1:0',
+        'anthropic.claude-opus-4-20250514-v1:0',
+        'anthropic.claude-sonnet-4-20250514-v1:0',
     ),
     ProviderVariants.GoogleVertex: (
         'claude-3-haiku@20240307',
@@ -203,6 +211,8 @@ _model_names = __.DictionaryProxy( {
         'claude-3-5-sonnet@20240620',
         'claude-3-5-sonnet-v2@20241022',
         'claude-3-7-sonnet@20250219',
+        'claude-opus-4@20250514',
+        'claude-sonnet-4@20250514',
     ),
 } )
 # TODO? Use for AWS Bedrock and Google Vertex.

--- a/sources/aiwb/providers/clients/anthropic/clients.py
+++ b/sources/aiwb/providers/clients/anthropic/clients.py
@@ -187,9 +187,7 @@ _model_names = __.DictionaryProxy( {
         'claude-3-5-sonnet-latest',
         'claude-3-7-sonnet-20250219',
         'claude-3-7-sonnet-latest',
-        'claude-opus-4-0',
         'claude-opus-4-20250514',
-        'claude-sonnet-4-0',
         'claude-sonnet-4-20250514',
     ),
     ProviderVariants.AwsBedrock: (


### PR DESCRIPTION
Adds support for the new Anthropic Claude Sonnet 4.0 and Opus 4.0 models to the provider configuration system.

## Summary
- Create model family configurations for claude-sonnet-4 and claude-opus-4
- Add support for computer use and extended thinking placeholders
- Update client aliases to include claude-sonnet-4-0 and claude-opus-4-0
- Add model names to all provider variants (Anthropic, AWS Bedrock, Google Vertex)

Fixes #8

Generated with [Claude Code](https://claude.ai/code)