### PR TITLE
refactor: use cabc types directly

### DIFF
--- a/sources/aiwb/__.py
+++ b/sources/aiwb/__.py
@@ -36,17 +36,6 @@ from asyncio import (
     Lock as MutexAsync,
 )
 from collections import namedtuple # TODO: Replace with dataclass.
-from collections.abc import (
-    Awaitable as        AbstractAwaitable,
-    Collection as       AbstractCollection,
-    Coroutine as        AbstractCoroutine,
-    Mapping as          AbstractDictionary,
-    Iterable as         AbstractIterable,
-    AsyncIterable as    AbstractIterableAsync,
-    MutableMapping as   AbstractMutableDictionary,
-    MutableSequence as  AbstractMutableSequence,
-    Sequence as         AbstractSequence,
-)
 from contextlib import (
     ExitStack as            Exits,
     AsyncExitStack as       ExitsAsync,
@@ -95,10 +84,12 @@ from absence import Absential, absent, is_absent
 
 from . import _generics as g
 
-ClassDecorators: typx.TypeAlias = AbstractIterable[ typx.Callable[ [ type ], type ] ]
-NominativeArgumentsDictionary: typx.TypeAlias = AbstractDictionary[ str, typx.Any ]
+ClassDecorators: typx.TypeAlias = cabc.Iterable[
+    typx.Callable[ [ type ], type ]
+]
+NominativeArgumentsDictionary: typx.TypeAlias = cabc.Mapping[ str, typx.Any ]
 TextComparand: typx.TypeAlias = str | re.Pattern
-TextComparands: typx.TypeAlias = AbstractIterable[ TextComparand ]
+TextComparands: typx.TypeAlias = cabc.Iterable[ TextComparand ]
 
 
 _immutability_label = 'immutability'
@@ -115,10 +106,10 @@ def calculate_class_fqname( class_: type ) -> str:
     return f"{class_.__module__}.{class_.__qualname__}"
 
 
-async def chain_async( *iterables: AbstractIterable | AbstractIterableAsync ):
+async def chain_async( *iterables: cabc.Iterable | cabc.AsyncIterable ):
     ''' Chains items from iterables in sequence and asynchronously. '''
     for iterable in iterables:
-        if isinstance( iterable, AbstractIterableAsync ):
+        if isinstance( iterable, cabc.AsyncIterable ):
             async for item in iterable: yield item
         else:
             for item in iterable: yield item
@@ -142,7 +133,7 @@ async def gather_async(
         bool,
         typx.Doc( ''' Ignore or error on non-awaitables. Ignore, if true. ''' )
     ] = False,
-) -> AbstractSequence:
+) -> cabc.Sequence:
     ''' Gathers results from invocables concurrently and asynchronously. '''
     from exceptiongroup import ExceptionGroup # TODO: Python 3.11: builtin
     if ignore_nonawaitables:
@@ -155,7 +146,7 @@ async def gather_async(
     return tuple( result.extract( ) for result in results )
 
 
-async def intercept_error_async( awaitable: AbstractAwaitable ) -> g.Result:
+async def intercept_error_async( awaitable: cabc.Awaitable ) -> g.Result:
     ''' Converts unwinding exceptions to error results.
 
         Exceptions, which are not instances of :py:exc:`Exception` or one of
@@ -178,9 +169,9 @@ async def intercept_error_async( awaitable: AbstractAwaitable ) -> g.Result:
 
 async def read_files_async(
     *files: PathLike,
-    deserializer: typx.Callable[ [ str ], typx.Any ] = None,
+    deserializer: typx.Callable[[str], typx.Any] | None = None,
     return_exceptions: bool = False
-) -> AbstractSequence:
+) -> cabc.Sequence:
     ''' Reads files asynchronously. '''
     # TODO? Batch to prevent fd exhaustion over large file sets.
     from aiofiles import open as open_
@@ -207,11 +198,11 @@ async def read_files_async(
 
 async def _gather_async_permissive(
     operands: typx.Any
-) -> AbstractSequence:
+) -> cabc.Sequence:
     from asyncio import gather # TODO? Python 3.11: TaskGroup
     awaitables = { }
     for i, operand in enumerate( operands ):
-        if isinstance( operand, AbstractAwaitable ):
+        if isinstance( operand, cabc.Awaitable ):
             awaitables[ i ] = intercept_error_async( operand )
     results_ = await gather( *awaitables.values( ) )
     results = list( operands )
@@ -222,11 +213,11 @@ async def _gather_async_permissive(
 
 async def _gather_async_strict(
     operands: typx.Any
-) -> AbstractSequence:
+) -> cabc.Sequence:
     from asyncio import gather # TODO? Python 3.11: TaskGroup
     awaitables = [ ]
     for operand in operands:
-        if not isinstance( operand, AbstractAwaitable ):
+        if not isinstance( operand, cabc.Awaitable ):
             raise ValueError( f"Operand {operand!r} must be awaitable." )
         awaitables.append( intercept_error_async( operand ) )
     return await gather( *awaitables )

--- a/sources/aiwb/apiserver/cli.py
+++ b/sources/aiwb/apiserver/cli.py
@@ -51,7 +51,7 @@ class Cli( __.ApplicationCli ):
 
     def prepare_invocation_args(
         self,
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         args = __.ApplicationCli.prepare_invocation_args( self )
         args[ 'apiserver' ] = self.apiserver
         return args

--- a/sources/aiwb/apiserver/server.py
+++ b/sources/aiwb/apiserver/server.py
@@ -74,7 +74,7 @@ async def prepare(
 @__.exit_manager_async
 async def _execute_server_thread(
     server: __.UvicornServer,
-    nomargs: __.AbstractDictionary[ str, __.typx.Any ],
+    nomargs: __.cabc.Mapping[ str, __.typx.Any ],
 ) -> __.cabc.AsyncGenerator:
     scribe = __.acquire_scribe( __package__ )
     from asyncio import sleep

--- a/sources/aiwb/appcore/cli.py
+++ b/sources/aiwb/appcore/cli.py
@@ -41,7 +41,7 @@ class Cli( __.CoreCli ):
 
     def prepare_invocation_args(
         self,
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         args = __.CoreCli.prepare_invocation_args( self )
         args[ 'configedits' ] = self.configuration.as_edits( )
         return args
@@ -89,49 +89,49 @@ class ConfigurationModifiers( __.immut.DataclassObject ):
         __.tyro.conf.arg( prefix_name = False ),
     ] = EnablementTristate.Retain
     disable_promptstores: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'disable-promptstore', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     enable_promptstores: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'enable-promptstore', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     disable_providers: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'disable-provider', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     enable_providers: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'enable-provider', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     disable_vectorizers: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'disable-vectorizer', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     enable_vectorizers: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'enable-vectorizer', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     disable_vectorstores: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'disable-vectorstore', prefix_name = False ),
         __.tyro.conf.UseAppendAction,
     ] = ( )
     enable_vectorstores: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg(
             name = 'enable-vectorstore', prefix_name = False ),
         __.tyro.conf.UseAppendAction,

--- a/sources/aiwb/controls/core.py
+++ b/sources/aiwb/controls/core.py
@@ -192,7 +192,7 @@ class FlexArray( DefinitionBase ):
     def validate_value( self, value ):
         elements = value
         element_class = self.element_definition.Instance
-        if not isinstance( elements, __.AbstractSequence ):
+        if not isinstance( elements, __.cabc.Sequence ):
             raise ValueError(
                 "Array of controls expected; "
                 "received instance of '{class_name}'.".format(
@@ -217,7 +217,7 @@ class Options( DefinitionBase ):
         return next( iter( descriptor[ 'options' ] ) )
 
     def __init__( self, name, options, **nomargs ):
-        if not isinstance( options, __.AbstractCollection ):
+        if not isinstance( options, __.cabc.Collection ):
             raise ValueError # TODO: Fill out error.
         self.options = options
         super( ).__init__( name, **nomargs )
@@ -243,7 +243,7 @@ class Text( DefinitionBase ):
 
 # TODO: Python 3.12: Use type statement for aliases.
 ControlsInstancesByName: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, DefinitionBase.Instance ] )
+    __.cabc.Mapping[ str, DefinitionBase.Instance ] )
 
 
 def descriptor_to_definition( descriptor ):

--- a/sources/aiwb/gui/actions.py
+++ b/sources/aiwb/gui/actions.py
@@ -251,7 +251,7 @@ async def _deactivate_duplicate_invocations( components ):
 
 async def _deduplicate_invocations(
     components
-) -> __.AbstractSequence[ int ]:
+) -> __.cabc.Sequence[ int ]:
     ''' Deduplicates invocations and their results. '''
     history = components.column_conversation_history
     deduplicators = { }  # { tool_name: [ deduplicator_instances ] }

--- a/sources/aiwb/gui/classes.py
+++ b/sources/aiwb/gui/classes.py
@@ -578,7 +578,7 @@ class ConversationDescriptor(
     timestamp: int = (
         __.dataclass_declare( default_factory = __.time_ns ) )
     title: __.typx.Optional[ str ] = None
-    labels: __.AbstractMutableSequence[ str ] = (
+    labels: __.cabc.MutableSequence[ str ] = (
         __.dataclass_declare( default_factory = list ) )
     gui: __.typx.Optional[ __.SimpleNamespace ] = None
     indicator: __.typx.Optional[ Row ] = None

--- a/sources/aiwb/gui/cli.py
+++ b/sources/aiwb/gui/cli.py
@@ -51,7 +51,7 @@ class Cli( __.ApiServerCli ):
 
     def prepare_invocation_args(
         self,
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         args = __.ApiServerCli.prepare_invocation_args( self )
         args[ 'guiserver' ] = self.guiserver
         return args

--- a/sources/aiwb/gui/persistence.py
+++ b/sources/aiwb/gui/persistence.py
@@ -205,7 +205,7 @@ async def restore_prompt_variables( components, row_name, state, species ):
     ''' Restores prompt variables from loaded state. '''
     from .updaters import populate_prompt_variables
     container_state = state.get( row_name )
-    if not isinstance( container_state, __.AbstractDictionary ):
+    if not isinstance( container_state, __.cabc.Mapping ):
         container_state = _restore_prompt_variables_v0(
             components, container_state, species = species )
     await populate_prompt_variables(

--- a/sources/aiwb/gui/updaters.py
+++ b/sources/aiwb/gui/updaters.py
@@ -35,8 +35,8 @@ class UpdateRequest(
     ''' Request for update which may be deduplicated. '''
 
     updater: __.typx.Callable[ ..., __.typx.Any ]
-    posargs: __.AbstractSequence[ __.typx.Any ] = ( )
-    nomargs: __.AbstractDictionary[ str, __.typx.Any ] = __.DictionaryProxy( { } )
+    posargs: __.cabc.Sequence[ __.typx.Any ] = ( )
+    nomargs: __.cabc.Mapping[ str, __.typx.Any ] = __.DictionaryProxy( { } )
 
     def __hash__( self ) -> int:
         return hash( (
@@ -77,7 +77,7 @@ class UpdatesDeduplicator(
         __.dataclass_declare( default_factory = set ) )
     updates_mutexes: dict[ UpdateRequest, __.MutexAsync ] = (
         __.dataclass_declare( default_factory = dict ) )
-    updates_tasks: dict[ UpdateRequest, __.AbstractCoroutine ] = (
+    updates_tasks: dict[ UpdateRequest, __.cabc.Coroutine ] = (
         __.dataclass_declare( default_factory = dict ) )
 
     async def __aenter__( self ): return self
@@ -110,8 +110,8 @@ class UpdatesDeduplicator(
     async def execute(
         self,
         updater: __.typx.Callable[ ..., __.typx.Any ],
-        posargs: __.AbstractSequence[ __.typx.Any ] = ( ),
-        nomargs: __.AbstractDictionary[ str, __.typx.Any ] = (
+        posargs: __.cabc.Sequence[ __.typx.Any ] = ( ),
+        nomargs: __.cabc.Mapping[ str, __.typx.Any ] = (
             __.DictionaryProxy( { } ) ),
     ) -> None:
         ''' Executes update if not already in progress. '''
@@ -141,8 +141,8 @@ class UpdatesDeduplicator(
     async def schedule(
         self,
         updater: __.typx.Callable[ ..., __.typx.Any ],
-        posargs: __.AbstractSequence[ __.typx.Any ] = ( ),
-        nomargs: __.AbstractDictionary[ str, __.typx.Any ] = (
+        posargs: __.cabc.Sequence[ __.typx.Any ] = ( ),
+        nomargs: __.cabc.Mapping[ str, __.typx.Any ] = (
             __.DictionaryProxy( { } ) ),
         delay: float = 0.1,  # seconds
     ) -> None:

--- a/sources/aiwb/invocables/core.py
+++ b/sources/aiwb/invocables/core.py
@@ -38,18 +38,18 @@ class Deduplicator(
     ''' Determines if tool invocations can be deduplicated. '''
 
     invocable_name: str
-    arguments: __.AbstractDictionary[ str, __.typx.Any ]
+    arguments: __.cabc.Mapping[ str, __.typx.Any ]
 
     @classmethod
     @__.abstract_member_function
-    def provide_invocable_names( selfclass ) -> __.AbstractCollection[ str ]:
+    def provide_invocable_names( selfclass ) -> __.cabc.Collection[ str ]:
         raise NotImplementedError
 
     @__.abstract_member_function
     def is_duplicate(
         self,
         invocable_name: str,
-        arguments: __.AbstractDictionary[ str, __.typx.Any ],
+        arguments: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> bool:
         raise NotImplementedError
 
@@ -75,12 +75,12 @@ class Ensemble(
     @__.abstract_member_function
     async def prepare_invokers(
         self, auxdata: __.Globals
-    ) -> __.AbstractDictionary[ str, 'Invoker' ]:
+    ) -> __.cabc.Mapping[ str, 'Invoker' ]:
         raise NotImplementedError
 
     def produce_invokers_from_registry(
         self, auxdata: __.Globals, registry
-    ) -> __.AbstractDictionary[ str, 'Invoker' ]:
+    ) -> __.cabc.Mapping[ str, 'Invoker' ]:
         # TODO: Handle pair-wise iterable or dictionary.
         # TODO: Use standard filter information.
         invokers = (
@@ -136,7 +136,7 @@ Invocable: __.typx.TypeAlias = (
     __.typx.Callable[
         [ __.Globals, 'Invoker', Arguments, __.accret.Namespace ],
         #[ Context, Arguments ],
-        __.AbstractCoroutine[ __.typx.Any, __.typx.Any, __.typx.Any ] ] )
+        __.cabc.Coroutine[ __.typx.Any, __.typx.Any, __.typx.Any ] ] )
 
 
 # TODO: Use accretive validator dictionary for preparers registry.
@@ -145,8 +145,8 @@ preparers = __.accret.Dictionary( )
 
 def descriptors_from_configuration(
     auxdata: __.Globals,
-    defaults: __.AbstractDictionary[ str, __.typx.Any ] = None,
-) -> __.AbstractSequence[ __.AbstractDictionary[ str, __.typx.Any ] ]:
+    defaults: __.cabc.Mapping[ str, __.typx.Any ] = None,
+) -> __.cabc.Sequence[ __.cabc.Mapping[ str, __.typx.Any ] ]:
     ''' Validates and returns descriptors from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     defaults_ = dict( defaults or { } )
@@ -200,8 +200,8 @@ async def prepare_ensembles( auxdata ):
 
 async def prepare_invokers(
     auxdata: __.Globals,
-    ensembles: __.AbstractDictionary[ str, Ensemble ],
-) -> __.AbstractDictionary[ str, 'Invoker' ]:
+    ensembles: __.cabc.Mapping[ str, Ensemble ],
+) -> __.cabc.Mapping[ str, 'Invoker' ]:
     ''' Prepares invokers from ensembles. '''
     scribe = __.acquire_scribe( __package__ )
     results = await __.gather_async(
@@ -233,7 +233,7 @@ _default_ensemble_descriptors = __.DictionaryProxy( {
 def _trim_descriptions( schema ):
     from inspect import cleandoc
     for entry_name, entry in schema.items( ):
-        if isinstance( entry, __.AbstractDictionary ):
+        if isinstance( entry, __.cabc.Mapping ):
             _trim_descriptions( entry )
         if 'description' != entry_name: continue
         if not isinstance( entry, str ): continue

--- a/sources/aiwb/invocables/ensembles/io/__init__.py
+++ b/sources/aiwb/invocables/ensembles/io/__init__.py
@@ -39,7 +39,7 @@ _name = __package__.rsplit( '.', maxsplit = 1 )[ -1 ]
 
 async def prepare(
     auxdata: __.Globals,
-    descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+    descriptor: __.cabc.Mapping[ str, __.typx.Any ],
 ) -> 'Ensemble':
     ''' Installs dependencies and returns ensemble. '''
     # TODO: Install dependencies: github, etc....
@@ -53,7 +53,7 @@ class Ensemble( __.Ensemble ):
 
     async def prepare_invokers(
         self, auxdata: __.Globals
-    ) -> __.AbstractDictionary[ str, __.Invoker ]:
+    ) -> __.cabc.Mapping[ str, __.Invoker ]:
         registry = [
             (   invocable,
                 argschema,

--- a/sources/aiwb/invocables/ensembles/io/deduplicators.py
+++ b/sources/aiwb/invocables/ensembles/io/deduplicators.py
@@ -48,13 +48,13 @@ class IoContentDeduplicator( __.Deduplicator ):
     ''' Deduplicates I/O content operations. '''
 
     @classmethod
-    def provide_invocable_names( selfclass ) -> __.AbstractCollection[ str ]:
+    def provide_invocable_names( selfclass ) -> __.cabc.Collection[ str ]:
         return { 'read', 'write_file', 'write_pieces' }
 
     def is_duplicate(
         self,
         invocable_name: str,
-        arguments: __.AbstractDictionary[ str, __.typx.Any ],
+        arguments: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> bool:
         our_location = self.arguments.get( 'location' )
         their_location = arguments.get( 'location' )
@@ -71,13 +71,13 @@ class SurveyDirectoryDeduplicator( __.Deduplicator ):
     ''' Deduplicates directory survey operations. '''
 
     @classmethod
-    def provide_invocable_names( selfclass ) -> __.AbstractCollection[ str ]:
+    def provide_invocable_names( selfclass ) -> __.cabc.Collection[ str ]:
         return { 'list_folder' }
 
     def is_duplicate(
         self,
         invocable_name: str,
-        arguments: __.AbstractDictionary[ str, __.typx.Any ],
+        arguments: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> bool:
         our_location = self.arguments.get( 'location' )
         their_location = arguments.get( 'location' )

--- a/sources/aiwb/invocables/ensembles/io/differences.py
+++ b/sources/aiwb/invocables/ensembles/io/differences.py
@@ -107,7 +107,7 @@ def assess_overlap( op1: Operation, op2: Operation ) -> bool:
 
 
 def verify_operations(
-    operations: __.AbstractSequence[ Operation ], file_length: int
+    operations: __.cabc.Sequence[ Operation ], file_length: int
 ) -> list[ Operation ]:
     ''' Verifies all operations are valid and non-overlapping. '''
     if not operations: return [ ]
@@ -126,7 +126,7 @@ def verify_operations(
 
 
 def apply_operations(
-    lines: list[ str ], operations: __.AbstractSequence[ Operation ]
+    lines: list[ str ], operations: __.cabc.Sequence[ Operation ]
 ) -> list[ str ]:
     ''' Applies sequence of operations to content lines. '''
     if not operations: return lines
@@ -168,7 +168,7 @@ async def acquire_content( accessor: __.FileAccessor ) -> tuple[ str, int ]:
 
 async def update_content(
     accessor: __.FileAccessor, content: str
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     ''' Updates file with modified content. '''
     presenter = __.text_file_presenter_from_accessor( accessor = accessor )
     result = await presenter.update_content(
@@ -183,7 +183,7 @@ async def update_content(
 
 async def write_pieces(
     context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     ''' Modifies file at URL or filesystem path with partial content updates.
 
         Operations can insert, delete, or replace content at specific line

--- a/sources/aiwb/invocables/ensembles/io/operations.py
+++ b/sources/aiwb/invocables/ensembles/io/operations.py
@@ -26,7 +26,7 @@ from . import __
 
 async def list_folder(
     context: __.Context, arguments: __.Arguments,
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     ''' Lists directory at URL or filesystem path.
 
         May be recursive or single level.
@@ -60,7 +60,7 @@ async def list_folder(
 
 async def read(
     context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     ''' Reads file at URL or filesystem path.
 
         Metadata includes location and MIME type.
@@ -86,7 +86,7 @@ async def read(
 
 async def write_file(
     context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     ''' Writes file at URL or filesystem path.
 
         Options can control update behavior.
@@ -99,7 +99,7 @@ async def write_file(
     if 'content' not in arguments:
         return { 'error': "Argument 'content' is required." }
     options = arguments.get( 'options', ( ) )
-    if not isinstance( options, __.AbstractSequence ):
+    if not isinstance( options, __.cabc.Sequence ):
         return { 'error': "Argument 'options' must be a list." }
     try:
         accessor = await __.accessor_from_arguments(
@@ -118,7 +118,7 @@ async def write_file(
 
 async def _read_as_bytes(
     accessor: __.FileAccessor, context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     try: result = await accessor.acquire_content_result( )
     except Exception as exc:
         # TODO? Generate apprisal notification.
@@ -136,7 +136,7 @@ async def _read_as_bytes(
 
 async def _read_as_string(
     accessor: __.FileAccessor, context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     presenter = __.text_file_presenter_from_accessor(
         accessor = accessor, charset = '#DETECT#' )
     try: result = await presenter.acquire_content_result( )
@@ -157,7 +157,7 @@ async def _read_as_string(
 
 async def _write_as_string(
     accessor: __.FileAccessor, context: __.Context, arguments: __.Arguments
-) -> __.AbstractDictionary:
+) -> __.cabc.Mapping:
     presenter = __.text_file_presenter_from_accessor( accessor = accessor )
     content = arguments[ 'content' ]
     options = arguments.get( 'options', ( ) )

--- a/sources/aiwb/invocables/ensembles/probability/__init__.py
+++ b/sources/aiwb/invocables/ensembles/probability/__init__.py
@@ -31,7 +31,7 @@ _name = __package__.rsplit( '.', maxsplit = 1 )[ -1 ]
 
 async def prepare(
     auxdata: __.Globals,
-    descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+    descriptor: __.cabc.Mapping[ str, __.typx.Any ],
 ) -> 'Ensemble':
     ''' Returns ensemble. '''
     return Ensemble( name = _name )
@@ -43,7 +43,7 @@ class Ensemble( __.Ensemble ):
 
     async def prepare_invokers(
         self, auxdata: __.Globals
-    ) -> __.AbstractDictionary[ str, __.Invoker ]:
+    ) -> __.cabc.Mapping[ str, __.Invoker ]:
         return self.produce_invokers_from_registry( auxdata, _invocables )
 
 

--- a/sources/aiwb/invocables/ensembles/probability/calculations.py
+++ b/sources/aiwb/invocables/ensembles/probability/calculations.py
@@ -26,7 +26,7 @@ from . import __
 
 async def roll_dice(
     context: __.Context, arguments: __.Arguments
-) -> __.AbstractSequence:
+) -> __.cabc.Sequence:
     ''' Returns results of rolls for each named dice specification. '''
     return tuple(
         { spec[ 'name' ]: _roll_dice( spec[ 'dice' ] ) }

--- a/sources/aiwb/invocables/ensembles/summarization/__init__.py
+++ b/sources/aiwb/invocables/ensembles/summarization/__init__.py
@@ -31,7 +31,7 @@ _name = __package__.rsplit( '.', maxsplit = 1 )[ -1 ]
 
 async def prepare(
     auxdata: __.Globals,
-    descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+    descriptor: __.cabc.Mapping[ str, __.typx.Any ],
 ) -> 'Ensemble':
     ''' Returns ensemble. '''
     return Ensemble( name = _name )
@@ -43,7 +43,7 @@ class Ensemble( __.Ensemble ):
 
     async def prepare_invokers(
         self, auxdata: __.Globals
-    ) -> __.AbstractDictionary[ str, __.Invoker ]:
+    ) -> __.cabc.Mapping[ str, __.Invoker ]:
         return self.produce_invokers_from_registry( auxdata, _invocables )
 
 

--- a/sources/aiwb/invocables/ensembles/summarization/operations.py
+++ b/sources/aiwb/invocables/ensembles/summarization/operations.py
@@ -26,7 +26,7 @@ from . import __
 
 async def analyze(
     context: __.Context, arguments: __.Arguments
-) -> __.AbstractSequence:
+) -> __.cabc.Sequence:
     ''' Reads URL or filesystem path and analyzes contents with an AI agent.
 
         AI agent analyzes contents according to instructions and returns

--- a/sources/aiwb/libcore/cli.py
+++ b/sources/aiwb/libcore/cli.py
@@ -65,7 +65,7 @@ class Cli(
 
     def prepare_invocation_args(
         self,
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         args = dict(
             application = self.application,
             environment = True,
@@ -235,7 +235,7 @@ class LocationSurveyDirectoryCommand( metaclass = __.accret.Dataclass ):
     # TODO: Cache options.
 
     filters: __.typx.Annotated[
-        __.AbstractSequence[ str ],
+        __.cabc.Sequence[ str ],
         __.tyro.conf.arg( prefix_name = False ),
     ] = ( '@gitignore', '+vcs' )
     recurse: __.typx.Annotated[

--- a/sources/aiwb/libcore/configuration.py
+++ b/sources/aiwb/libcore/configuration.py
@@ -58,7 +58,7 @@ async def _acquire_includes(
     application_name: str,
     directories: __.PlatformDirs,
     specs: tuple[ str ]
-) -> __.AbstractSequence[ dict ]:
+) -> __.cabc.Sequence[ dict ]:
     from itertools import chain
     from tomli import loads
     locations = tuple(

--- a/sources/aiwb/libcore/dictedits.py
+++ b/sources/aiwb/libcore/dictedits.py
@@ -32,16 +32,16 @@ class Edit(
 ):
     ''' Base representation of an edit to configuration. '''
 
-    address: __.AbstractSequence[ str ]
+    address: __.cabc.Sequence[ str ]
 
     @__.abstract_member_function
-    def __call__( self, configuration: __.AbstractMutableDictionary ):
+    def __call__( self, configuration: __.cabc.MutableMapping ):
         ''' Performs edit. '''
         raise NotImplementedError
 
     def dereference(
         self,
-        configuration: __.AbstractMutableDictionary
+        configuration: __.cabc.MutableMapping
     ) -> __.typx.Any:
         ''' Dereferences value at address in configuration. '''
         configuration_ = configuration
@@ -52,7 +52,7 @@ class Edit(
 
     def inject(
         self,
-        configuration: __.AbstractMutableDictionary,
+        configuration: __.cabc.MutableMapping,
         value: __.typx.Any
     ):
         ''' Injects value at address in configuration. '''
@@ -69,7 +69,7 @@ class ElementsEntryEdit( Edit ):
     editee: tuple[ str, __.typx.Any ]
     identifier: __.typx.Optional[ tuple[ str, __.typx.Any ] ] = None
 
-    def __call__( self, configuration: __.AbstractMutableDictionary ):
+    def __call__( self, configuration: __.cabc.MutableMapping ):
         array = self.dereference( configuration )
         if self.identifier: iname, ivalue = self.identifier
         else: iname, ivalue = None, None
@@ -86,9 +86,9 @@ class SimpleEdit( Edit ):
 
     value: __.typx.Any
 
-    def __call__( self, configuration: __.AbstractMutableDictionary ):
+    def __call__( self, configuration: __.cabc.MutableMapping ):
         self.inject( configuration, self.value )
 
 
 # TODO: Python 3.12: Use type statement for aliases.
-Edits: __.typx.TypeAlias = __.AbstractIterable[ Edit ]
+Edits: __.typx.TypeAlias = __.cabc.Iterable[ Edit ]

--- a/sources/aiwb/libcore/locations/adapters/aiofiles.py
+++ b/sources/aiwb/libcore/locations/adapters/aiofiles.py
@@ -283,7 +283,7 @@ class DirectoryAdapter( _Common, __.DirectoryAdapter ):
         self, name: __.PossibleRelativeLocator
     ) -> __.GeneralAccessor:
         if isinstance( name, __.PossiblePath ): name = ( name, )
-        if isinstance( name, __.AbstractIterable[ __.PossiblePath ] ):
+        if isinstance( name, __.cabc.Iterable[ __.PossiblePath ] ):
             return __.adapter_from_url(
                 self.url.with_path(
                     __.Path( self.url.path ).joinpath( *name ) ) )
@@ -293,10 +293,10 @@ class DirectoryAdapter( _Common, __.DirectoryAdapter ):
         self,
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         filters: __.Absential[
-            __.AbstractIterable[ __.PossibleFilter ]
+            __.cabc.Iterable[ __.PossibleFilter ]
         ] = __.absent,
         recurse: bool = True
-    ) -> __.AbstractSequence[ __.DirectoryEntry ]:
+    ) -> __.cabc.Sequence[ __.DirectoryEntry ]:
         from aiofiles.os import scandir
         if filters: filters = __.filters_from_specifiers( filters )
         scanners = [ ]

--- a/sources/aiwb/libcore/locations/adapters/httpx.py
+++ b/sources/aiwb/libcore/locations/adapters/httpx.py
@@ -256,7 +256,7 @@ async def register_defaults( ):
 
 
 def _expiration_from_headers(
-    headers: __.AbstractDictionary[ str, str ]
+    headers: __.cabc.Mapping[ str, str ]
 ) -> __.typx.Optional[ __.DateTime ]:
     from email.utils import parsedate_to_datetime
     cache_control = headers.get( 'Cache-Control' )
@@ -279,7 +279,7 @@ def _expiration_from_headers(
 
 def _headers_from_file_update_options(
     options: __.FileUpdateOptions, inode: __.Inode, content: bytes
-) -> __.AbstractDictionary[ str, str ]:
+) -> __.cabc.Mapping[ str, str ]:
     is_void = __.LocationSpecies.Void is inode.species
     headers = { }
     if __.FileUpdateOptions.Absence & options:
@@ -296,7 +296,7 @@ def _headers_from_file_update_options(
 
 
 def _inode_from_headers(
-    headers: __.AbstractDictionary[ str, str ],
+    headers: __.cabc.Mapping[ str, str ],
     permissions: __.Permissions,
     species: __.LocationSpecies,
 ) -> __.Inode:
@@ -325,7 +325,7 @@ def _inode_from_headers(
 
 
 def _methods_to_permissions(
-    methods: __.AbstractCollection[ str ]
+    methods: __.cabc.Collection[ str ]
 ) -> __.Permissions:
     permissions = __.Permissions.Abstain
     if 'GET' in methods:

--- a/sources/aiwb/libcore/locations/caches/simple.py
+++ b/sources/aiwb/libcore/locations/caches/simple.py
@@ -146,7 +146,7 @@ class CacheManager( __.CacheManager ):
 
     async def difference(
         self
-    ) -> __.AbstractSequence[ __.CacheDifferenceBase ]:
+    ) -> __.cabc.Sequence[ __.CacheDifferenceBase ]:
         # No concept of aliens or impurities. Everything is considered.
         # TODO: Implement.
         pass
@@ -345,7 +345,7 @@ class DirectoryCache( _Common, __.DirectoryCache ):
         self, name: __.PossibleRelativeLocator
     ) -> __.GeneralAccessor:
         if isinstance( name, __.PossiblePath ): name = ( name, )
-        if isinstance( name, __.AbstractIterable[ __.PossiblePath ] ):
+        if isinstance( name, __.cabc.Iterable[ __.PossiblePath ] ):
             source_base_url = self.adapter.as_url( )
             source_url = source_base_url.with_path(
                 __.Path( source_base_url.path ).joinpath( *name ) )
@@ -361,10 +361,10 @@ class DirectoryCache( _Common, __.DirectoryCache ):
         self,
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         filters: __.Absential[
-            __.AbstractIterable[ __.PossibleFilter ]
+            __.cabc.Iterable[ __.PossibleFilter ]
         ] = __.absent,
         recurse: bool = True
-    ) -> __.AbstractSequence[ __.DirectoryEntry ]:
+    ) -> __.cabc.Sequence[ __.DirectoryEntry ]:
         cache_adapter = __.adapter_from_url( self.cache_url )
         return await cache_adapter.survey_entries(
             attributes = attributes, filters = filters, recurse = recurse )

--- a/sources/aiwb/libcore/locations/core.py
+++ b/sources/aiwb/libcore/locations/core.py
@@ -325,19 +325,19 @@ class Url(
 
 # TODO: Python 3.12: type statement for aliases
 AlienResolutionActionsTable: __.typx.TypeAlias = (
-    __.AbstractDictionary[ Url, AlienResolutionActions ] )
+    __.cabc.Mapping[ Url, AlienResolutionActions ] )
 ConflictResolutionActionsTable: __.typx.TypeAlias = (
-    __.AbstractDictionary[ Url, ConflictResolutionActions ] )
+    __.cabc.Mapping[ Url, ConflictResolutionActions ] )
 ImpurityResolutionActionsTable: __.typx.TypeAlias = (
-    __.AbstractDictionary[ Url, ImpurityResolutionActions ] )
+    __.cabc.Mapping[ Url, ImpurityResolutionActions ] )
 PermissionsTable: __.typx.TypeAlias = (
-    __.AbstractDictionary[ Possessor, Permissions ] )
+    __.cabc.Mapping[ Possessor, Permissions ] )
 PossibleUrl: __.typx.TypeAlias = bytes | str | __.PathLike | _UrlParts
 
 
 def is_permissions_table( table: __.typx.Any ) -> bool:
     ''' Validates table is mapping from possessors to permissions. '''
-    if not isinstance( table, __.AbstractDictionary ): return False
+    if not isinstance( table, __.cabc.Mapping ): return False
     return all(
         isinstance( name, Possessor ) and isinstance( value, Permissions )
         for name, value in table.items( ) )

--- a/sources/aiwb/libcore/locations/filters/vcs.py
+++ b/sources/aiwb/libcore/locations/filters/vcs.py
@@ -54,7 +54,7 @@ class Filter( __.Filter ):
     '''
     # TODO: Immutable class and instance attributes.
 
-    matchers: __.AbstractSequence[ str ]
+    matchers: __.cabc.Sequence[ str ]
 
     def __init__( self, *arguments ):
         arguments_count = len( arguments )

--- a/sources/aiwb/libcore/locations/interfaces.py
+++ b/sources/aiwb/libcore/locations/interfaces.py
@@ -176,10 +176,10 @@ class DirectoryOperations(
         self,
         attributes: _core.InodeAttributes = _core.InodeAttributes.Nothing,
         filters: __.Absential[
-            __.AbstractIterable[ 'PossibleFilter' ]
+            __.cabc.Iterable[ 'PossibleFilter' ]
         ] = __.absent,
         recurse: bool = True,
-    ) -> __.AbstractSequence[ _core.DirectoryEntry ]:
+    ) -> __.cabc.Sequence[ _core.DirectoryEntry ]:
         ''' Returns list of directory entries, subject to filtering. '''
         raise NotImplementedError
 
@@ -320,7 +320,7 @@ class ReconciliationOperations(
     @__.abstract_member_function
     async def difference(
         self
-    ) -> __.AbstractSequence[ _core.CacheDifferenceBase ]:
+    ) -> __.cabc.Sequence[ _core.CacheDifferenceBase ]:
         ''' Reports differences between cache and sources. '''
         raise NotImplementedError
 
@@ -468,7 +468,7 @@ FileAccessor: __.typx.TypeAlias = 'FileAdapter | FileCache'
 GeneralAccessor: __.typx.TypeAlias = 'GeneralAdapter | GeneralCache'
 PossibleFilter: __.typx.TypeAlias = 'bytes | str | Filter'
 PossibleRelativeLocator: __.typx.TypeAlias = (
-    __.PossiblePath | __.AbstractIterable[ __.PossiblePath ] )
+    __.PossiblePath | __.cabc.Iterable[ __.PossiblePath ] )
 SpecificAccessor: __.typx.TypeAlias = 'DirectoryAccessor | FileAccessor'
 SpecificAdapter: __.typx.TypeAlias = 'DirectoryAdapter | FileAdapter'
 SpecificCache: __.typx.TypeAlias = 'DirectoryCache | FileCache'

--- a/sources/aiwb/libcore/locations/registries.py
+++ b/sources/aiwb/libcore/locations/registries.py
@@ -29,14 +29,14 @@ from . import interfaces as _interfaces
 
 # TODO: Python 3.12: type statement for aliases
 AdaptersRegistry: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, type[ '_interfaces.GeneralAdapter' ] ] )
+    __.cabc.Mapping[ str, type[ '_interfaces.GeneralAdapter' ] ] )
 CachesRegistry: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, type[ '_interfaces.CacheManager' ] ] )
+    __.cabc.Mapping[ str, type[ '_interfaces.CacheManager' ] ] )
 FilePresentersRegistry: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, type[ '_interfaces.FilePresenter' ] ] )
+    __.cabc.Mapping[ str, type[ '_interfaces.FilePresenter' ] ] )
 # TODO: Content filters versus dirent filters.
 FiltersRegistry: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, type[ '_interfaces.Filter' ] ] )
+    __.cabc.Mapping[ str, type[ '_interfaces.Filter' ] ] )
 
 
 # TODO: Use accretive validator dictionaries for registries.
@@ -58,7 +58,7 @@ def adapter_from_url( url: _core.PossibleUrl ) -> '_interfaces.GeneralAdapter':
 
 async def apply_filters(
     dirent: _core.DirectoryEntry,
-    filters: __.AbstractIterable[ '_interfaces.Filter' ],
+    filters: __.cabc.Iterable[ '_interfaces.Filter' ],
 ) -> bool:
     ''' Applies iterable of filters to directory entry. '''
     for filter_ in filters:
@@ -162,8 +162,8 @@ def text_file_presenter_from_url(
 
 
 def filters_from_specifiers(
-    filters: __.AbstractIterable[ '_interfaces.PossibleFilter' ]
-) -> __.AbstractSequence[ '_interfaces.Filter' ]:
+    filters: __.cabc.Iterable[ '_interfaces.PossibleFilter' ]
+) -> __.cabc.Sequence[ '_interfaces.Filter' ]:
     ''' Converts iterable of possible filters into filters. '''
     filters_ = [ ]
     for filter_ in filters:
@@ -182,7 +182,7 @@ def filters_from_specifiers(
 
 def _parse_filter_specifier(
     specifier: str
-) -> ( str, __.AbstractSequence[ __.typx.Any ] ):
+) -> ( str, __.cabc.Sequence[ __.typx.Any ] ):
     for index, delim in enumerate( specifier ):
         if ':' == delim: break
         if delim in ( '<', '>' ): break

--- a/sources/aiwb/libcore/state.py
+++ b/sources/aiwb/libcore/state.py
@@ -47,7 +47,7 @@ class Globals(
     exits: __.ExitsAsync # TODO? Make accretive.
     notifications: _notifications.Queue
 
-    def as_dictionary( self ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+    def as_dictionary( self ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         ''' Returns shallow copy of state. '''
         from dataclasses import fields
         return {

--- a/sources/aiwb/messages/core.py
+++ b/sources/aiwb/messages/core.py
@@ -149,7 +149,7 @@ class Canister(
 
     attributes: __.SimpleNamespace = (
         __.dataclass_declare( default_factory = __.SimpleNamespace ) )
-    contents: __.AbstractMutableSequence[ Content ] = (
+    contents: __.cabc.MutableSequence[ Content ] = (
         __.dataclass_declare( default_factory = list ) )
 
     def add_content( self, data, /, **descriptor ):
@@ -218,7 +218,7 @@ class UserCanister( Canister ):
 
 
 # TODO: Python 3.12: Use type statement for aliases.
-Canisters: __.typx.TypeAlias = __.AbstractIterable[ Canister ]
+Canisters: __.typx.TypeAlias = __.cabc.Iterable[ Canister ]
 
 
 # TODO: Cluster: Bundle of related canisters.

--- a/sources/aiwb/prompts/core.py
+++ b/sources/aiwb/prompts/core.py
@@ -62,7 +62,7 @@ class Definition(
     def instantiate_descriptor(
         selfclass,
         store: 'Store',
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ]
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ]
     ):
         return selfclass( store, **descriptor )
 
@@ -92,7 +92,7 @@ class Store(
     async def prepare(
         selfclass,
         auxdata: __.Globals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         args = selfclass.init_args_from_descriptor( auxdata, descriptor )
         return selfclass( **args )
@@ -101,8 +101,8 @@ class Store(
     def init_args_from_descriptor(
         selfclass,
         auxdata: __.Globals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         distribution = auxdata.distribution
         name = descriptor[ 'name' ]
         location = __.location_adapter_from_url(
@@ -118,7 +118,7 @@ class Store(
     async def acquire_definitions(
         self,
         auxdata: __.Globals,
-    ) -> __.AbstractDictionary[ str, 'Definition' ]:
+    ) -> __.cabc.Mapping[ str, 'Definition' ]:
         raise NotImplementedError
 
 
@@ -128,8 +128,8 @@ flavors = __.accret.Dictionary( )
 
 async def acquire_definitions(
     auxdata: __.Globals,
-    stores: __.AbstractDictionary[ str, 'Store' ],
-) -> __.AbstractDictionary[ str, Definition ]:
+    stores: __.cabc.Mapping[ str, 'Store' ],
+) -> __.cabc.Mapping[ str, Definition ]:
     ''' Loads prompt definitions from stores. '''
     scribe = __.acquire_scribe( __package__ )
     results = await __.gather_async(
@@ -150,7 +150,7 @@ async def acquire_definitions(
 
 async def acquire_stores(
     auxdata: __.Globals,
-) -> __.AbstractDictionary[ str, 'Store' ]:
+) -> __.cabc.Mapping[ str, 'Store' ]:
     ''' Loads configured promptstores. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = descriptors_from_configuration( auxdata )
@@ -174,7 +174,7 @@ async def acquire_stores(
 
 def descriptors_from_configuration(
     auxdata: __.Globals
-) -> __.AbstractSequence[ __.AbstractDictionary[ str, __.typx.Any ] ]:
+) -> __.cabc.Sequence[ __.cabc.Mapping[ str, __.typx.Any ] ]:
     ''' Validates and returns descriptors from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = [ ]

--- a/sources/aiwb/prompts/flavors/native.py
+++ b/sources/aiwb/prompts/flavors/native.py
@@ -37,7 +37,7 @@ class Definition( _core.Definition ):
         def __init__(
             self,
             definition: 'Definition',
-            values: __.AbstractDictionary[ str, __.typx.Any ] = None
+            values: __.cabc.Mapping[ str, __.typx.Any ] = None
         ):
             super( ).__init__( definition )
             values = values or { }
@@ -91,7 +91,7 @@ class Store( _core.Store ):
     async def acquire_definitions(
         self,
         auxdata: __.Globals,
-    ) -> __.AbstractDictionary[ str, 'Definition' ]:
+    ) -> __.cabc.Mapping[ str, 'Definition' ]:
         scribe = __.acquire_scribe( __package__ )
         location = self.location
         match location:

--- a/sources/aiwb/providers/clients/anthropic/clients.py
+++ b/sources/aiwb/providers/clients/anthropic/clients.py
@@ -33,7 +33,7 @@ else:
     _AsyncAnthropic: __.typx.TypeAlias = __.typx.Any
 
 
-ClientDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
+ClientDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 
 
 _model_genera = frozenset( (
@@ -82,7 +82,7 @@ class Client( __.Client ):
         self,
         auxdata: __.CoreGlobals,
         genus: __.Absential[ __.ModelGenera ] = __.absent,
-    ) -> __.AbstractSequence[ __.Model ]:
+    ) -> __.cabc.Sequence[ __.Model ]:
         if __.absent is genus: genera = _model_genera
         else:
             genus = __.typx.cast( __.ModelGenera, genus )
@@ -96,7 +96,7 @@ class Client( __.Client ):
                 acquirer = self._acquire_model_names ) )
 
     @__.abstract_member_function
-    async def _acquire_model_names( self ) -> __.AbstractSequence[ str ]:
+    async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         ''' Acquires model names from API or other source. '''
         raise NotImplementedError
 
@@ -117,7 +117,7 @@ class AnthropicClient( Client ):
         selfclass,
         auxdata: __.CoreGlobals,
         provider: __.Provider,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         await selfclass.assert_environment( auxdata )
         # TODO: Return future which acquires models in background.
@@ -135,7 +135,7 @@ class AnthropicClient( Client ):
     def variant( self ) -> ProviderVariants:
         return ProviderVariants.Anthropic
 
-    async def _acquire_model_names( self ) -> __.AbstractSequence[ str ]:
+    async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         aliases = (
             'claude-3-opus-latest',
             'claude-3-5-haiku-latest',
@@ -214,5 +214,5 @@ _model_names = __.DictionaryProxy( {
 # TODO? Use for AWS Bedrock and Google Vertex.
 async def _acquire_model_names(
     auxdata: __.CoreGlobals, client: Client
-) -> __.AbstractSequence[ str ]:
+) -> __.cabc.Sequence[ str ]:
     return _model_names[ client.variant ]

--- a/sources/aiwb/providers/clients/anthropic/conversers.py
+++ b/sources/aiwb/providers/clients/anthropic/conversers.py
@@ -32,8 +32,8 @@ from . import __
 AnthropicControls: __.typx.TypeAlias = dict[ str, __.typx.Any ]
 AnthropicMessage: __.typx.TypeAlias = dict[ str, __.typx.Any ]
 AnthropicMessageContent: __.typx.TypeAlias = str | list[ dict[ str, __.typx.Any ] ]
-AttributesDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
-ModelDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
+AttributesDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
+ModelDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 
 
 class NativeMessageRefinementActions( __.Enum ): # TODO: Python 3.11: StrEnum
@@ -117,7 +117,7 @@ class InvocationsProcessor( __.InvocationsProcessor ):
 
     def nativize_invocables(
         self,
-        invokers: __.AbstractIterable[ __.Invoker ],
+        invokers: __.cabc.Iterable[ __.Invoker ],
     ) -> __.typx.Any:
         # TODO: return type: list[ anthropic.types.ToolParam ]
         tools = [ self.nativize_invocable( invoker ) for invoker in invokers ]
@@ -295,7 +295,7 @@ class Tokenizer( __.ConversationTokenizer ):
 
 
 def _sanitize_messages_for_tokenization(
-    arguments: __.AbstractDictionary[ str, __.typx.Any ]
+    arguments: __.cabc.Mapping[ str, __.typx.Any ]
 ) -> tuple[ list[ AnthropicMessage ], int ]:
     messages = list( arguments[ 'messages' ] )
     # [anthropic.BadRequestError] Error code: 400

--- a/sources/aiwb/providers/clients/openai/clients.py
+++ b/sources/aiwb/providers/clients/openai/clients.py
@@ -33,7 +33,7 @@ else:
     _AsyncOpenAI: __.typx.TypeAlias = __.typx.Any
 
 
-ClientDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
+ClientDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 
 
 _model_genera = frozenset( (
@@ -81,7 +81,7 @@ class Client( __.Client ):
         self,
         auxdata: __.CoreGlobals,
         genus: __.Absential[ __.ModelGenera ] = __.absent,
-    ) -> __.AbstractSequence[ __.Model ]:
+    ) -> __.cabc.Sequence[ __.Model ]:
         if __.absent is genus: genera = _model_genera
         else:
             genus = __.typx.cast( __.ModelGenera, genus )
@@ -95,7 +95,7 @@ class Client( __.Client ):
                 acquirer = self._acquire_model_names ) )
 
     @__.abstract_member_function
-    async def _acquire_model_names( self ) -> __.AbstractSequence[ str ]:
+    async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         ''' Acquires model names from API or other source. '''
         raise NotImplementedError
 
@@ -120,7 +120,7 @@ class OpenAiClient( Client ):
         selfclass,
         auxdata: __.CoreGlobals,
         provider: __.Provider,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         await selfclass.assert_environment( auxdata )
         # TODO: Return future which acquires models in background.
@@ -138,7 +138,7 @@ class OpenAiClient( Client ):
     def variant( self ) -> ProviderVariants:
         return ProviderVariants.OpenAi
 
-    async def _acquire_model_names( self ) -> __.AbstractSequence[ str ]:
+    async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         return sorted( map(
             lambda model: model.id,
             ( await self.produce_implement( ).models.list( ) ).data ) )

--- a/sources/aiwb/providers/clients/openai/conversers.py
+++ b/sources/aiwb/providers/clients/openai/conversers.py
@@ -25,8 +25,8 @@ from . import __
 
 # TODO: Python 3.12: Use type statement for aliases.
 # TODO? Use typing.TypedDictionary.
-AttributesDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
-ModelDescriptor: __.typx.TypeAlias = __.AbstractDictionary[ str, __.typx.Any ]
+AttributesDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
+ModelDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 OpenAiControls: __.typx.TypeAlias = dict[ str, __.typx.Any ]
 OpenAiMessage: __.typx.TypeAlias = dict[ str, __.typx.Any ]
 OpenAiMessageContent: __.typx.TypeAlias = str | list[ dict[ str, __.typx.Any ] ]
@@ -144,7 +144,7 @@ class InvocationsProcessor( __.InvocationsProcessor ):
 
     def nativize_invocables(
         self,
-        invokers: __.AbstractIterable[ __.Invoker ],
+        invokers: __.cabc.Iterable[ __.Invoker ],
     ) -> __.typx.Any:
         if not self.model.attributes.supports_invocations: return { }
         args = { }

--- a/sources/aiwb/providers/core.py
+++ b/sources/aiwb/providers/core.py
@@ -30,18 +30,18 @@ NativeMessages = __.typx.TypeVar( 'NativeMessages', covariant = True )
 ProviderVariants = __.typx.TypeVar( 'ProviderVariants', covariant = True )
 
 InvocationDescriptor: __.typx.TypeAlias = (
-    __.AbstractDictionary[ str, __.typx.Any ] )
+    __.cabc.Mapping[ str, __.typx.Any ] )
 
 
 class ClientDefaults( __.immut.DataclassObject ):
     ''' Collection of default values for AI provider. '''
 
-    converser_model: __.AbstractSequence[ str ] = ( )
+    converser_model: __.cabc.Sequence[ str ] = ( )
 
     @classmethod
     def from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         ''' Produces client defaults instance from descriptor. '''
         args = __.accret.Dictionary( )
@@ -62,7 +62,7 @@ class ClientAttributes( __.immut.DataclassObject ):
     @classmethod
     def from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         ''' Produces client attributes instance from descriptor. '''
         return selfclass(
@@ -71,8 +71,8 @@ class ClientAttributes( __.immut.DataclassObject ):
     @classmethod
     def init_args_from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         ''' Extracts dictionary of initializer arguments from descriptor. '''
         args = __.accret.Dictionary( )
         args[ 'defaults' ] = (
@@ -143,7 +143,7 @@ class ConverserFormatPreferences(
     @classmethod
     def from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         args = __.accret.Dictionary( )
         for arg_species in ( 'data', 'math', 'text' ):
@@ -172,7 +172,7 @@ class ConverserTokensLimits(
     @classmethod
     def from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         args = __.accret.Dictionary( )
         for arg_name in ( 'per-response', 'total' ):
@@ -189,7 +189,7 @@ class InvocationRequest(
     ''' Provider-neutral invocation (tool use) request. '''
 
     name: str
-    arguments: __.AbstractDictionary[ str, __.typx.Any ]
+    arguments: __.cabc.Mapping[ str, __.typx.Any ]
     invocation: __.typx.Callable # TODO: Full signature.
     specifics: __.accret.Dictionary = ( # TODO: Full signature.
         __.dataclass_declare( default_factory = __.accret.Dictionary ) )
@@ -202,7 +202,7 @@ class InvocationRequest(
     ) -> __.typx.Self:
         ''' Produces instance from descriptor dictionary. '''
         from .exceptions import InvocationFormatError as Error
-        if not isinstance( descriptor, __.AbstractDictionary ):
+        if not isinstance( descriptor, __.cabc.Mapping ):
             raise Error( "Invocation descriptor is not dictionary." )
         if 'name' not in descriptor:
             raise Error( "Invocation descriptor without name." )
@@ -234,13 +234,13 @@ class ModelsIntegrator(
     ''' Integrates attributes from configuration for matching models. '''
     # TODO: Immutable class attributes.
 
-    attributes: __.AbstractDictionary[ str, __.typx.Any ]
+    attributes: __.cabc.Mapping[ str, __.typx.Any ]
     behaviors: ModelIntegrationBehaviors
     regex: __.re.Pattern
 
     @classmethod
     def from_descriptor(
-        selfclass, descriptor: __.AbstractDictionary[ str, __.typx.Any ]
+        selfclass, descriptor: __.cabc.Mapping[ str, __.typx.Any ]
     ) -> __.typx.Self:
         ''' Instance from configuration. '''
         desc = dict( descriptor )
@@ -254,8 +254,8 @@ class ModelsIntegrator(
             attributes = attributes, behaviors = behaviors, regex = regex )
 
     def __call__(
-        self, name: str, attributes: __.AbstractDictionary[ str, __.typx.Any ]
-    ) -> __.AbstractDictionary[ str, __.typx.Any ]:
+        self, name: str, attributes: __.cabc.Mapping[ str, __.typx.Any ]
+    ) -> __.cabc.Mapping[ str, __.typx.Any ]:
         ''' Returns integrated copy of model attributes. '''
         if not self.regex.match( name ): return attributes
         ours = dict( self.attributes )
@@ -284,30 +284,30 @@ class ModelGenera( __.Enum ): # TODO: Python 3.11: StrEnum
 
 # TODO: Python 3.12: Use type statement for aliases.
 InvocationsRequests: __.typx.TypeAlias = (
-    __.AbstractSequence[ InvocationRequest ] )
-ModelsIntegrators: __.typx.TypeAlias = __.AbstractSequence[ ModelsIntegrator ]
+    __.cabc.Sequence[ InvocationRequest ] )
+ModelsIntegrators: __.typx.TypeAlias = __.cabc.Sequence[ ModelsIntegrator ]
 ModelsIntegratorsMutable: __.typx.TypeAlias = (
-    __.AbstractMutableSequence[ ModelsIntegrator ] )
+    __.cabc.MutableSequence[ ModelsIntegrator ] )
 ModelsIntegratorsByGenus: __.typx.TypeAlias = (
-    __.AbstractDictionary[ ModelGenera, ModelsIntegrators ] )
+    __.cabc.Mapping[ ModelGenera, ModelsIntegrators ] )
 ModelsIntegratorsByGenusMutable: __.typx.TypeAlias = (
-    __.AbstractMutableDictionary[ ModelGenera, ModelsIntegratorsMutable ] )
+    __.cabc.MutableMapping[ ModelGenera, ModelsIntegratorsMutable ] )
 
 
 conversation_reactors_minimal = ConversationReactors( )
 
 
 def _merge_dictionaries_recursive(
-    theirs: __.AbstractMutableDictionary[ str, __.typx.Any ],
-    ours: __.AbstractDictionary[ str, __.typx.Any ],
+    theirs: __.cabc.MutableMapping[ str, __.typx.Any ],
+    ours: __.cabc.Mapping[ str, __.typx.Any ],
 ):
     for name, our_value in ours.items( ):
         if name not in theirs:
             theirs[ name ] = our_value
             continue
         their_value = theirs[ name ]
-        if (    not isinstance( their_value, __.AbstractDictionary )
-            or  not isinstance( our_value, __.AbstractDictionary )
+        if (    not isinstance( their_value, __.cabc.Mapping )
+            or  not isinstance( our_value, __.cabc.Mapping )
         ):
             theirs[ name ] = our_value
             continue

--- a/sources/aiwb/providers/interfaces.py
+++ b/sources/aiwb/providers/interfaces.py
@@ -36,7 +36,7 @@ class Provider(
 
     name: str
     # TODO: Reingester dictionary for configuration.
-    configuration: __.AbstractDictionary[ str, __.typx.Any ]
+    configuration: __.cabc.Mapping[ str, __.typx.Any ]
 
     def __str__( self ) -> str: return f"AI provider {self.name!r}"
 
@@ -44,7 +44,7 @@ class Provider(
     async def produce_client(
         self,
         auxdata: __.CoreGlobals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ]
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ]
     ) -> 'Client':
         ''' Produces client from descriptor dictionary. '''
         raise NotImplementedError
@@ -79,7 +79,7 @@ class Client(
         selfclass,
         auxdata: __.CoreGlobals,
         provider: 'Provider',
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         ''' Produces client from descriptor dictionary. '''
         raise NotImplementedError
@@ -89,7 +89,7 @@ class Client(
         selfclass,
         auxdata: __.CoreGlobals,
         provider: 'Provider',
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.NominativeArgumentsDictionary:
         ''' Extracts dictionary of initializer arguments from descriptor. '''
         descriptor_ = dict( descriptor )
@@ -162,7 +162,7 @@ class Client(
         self,
         auxdata: __.CoreGlobals,
         genus: __.Absential[ _core.ModelGenera ] = __.absent,
-    ) -> __.AbstractSequence[ 'Model' ]:
+    ) -> __.cabc.Sequence[ 'Model' ]:
         ''' Returns models available from provider.
 
             Accepts optional model genus as filter. If not supplied, then
@@ -186,7 +186,7 @@ class ControlsProcessor(
     model: 'Model'
 
     @property
-    def controls( self ) -> __.AbstractSequence[ __.Control ]:
+    def controls( self ) -> __.cabc.Sequence[ __.Control ]:
         ''' Array of controls available to model. '''
         return self.model.attributes.controls
 
@@ -201,7 +201,7 @@ class ControlsProcessor(
     @__.abstract_member_function
     def nativize_controls(
         self,
-        controls: __.AbstractDictionary[ str, __.Control.Instance ],
+        controls: __.cabc.Mapping[ str, __.Control.Instance ],
     ) -> _core.NativeControls:
         ''' Converts normalized controls into native arguments. '''
         raise NotImplementedError
@@ -256,7 +256,7 @@ class InvocationsProcessor(
     @__.abstract_member_function
     def nativize_invocables(
         self,
-        invokers: __.AbstractIterable[ __.Invoker ],
+        invokers: __.cabc.Iterable[ __.Invoker ],
     ) -> __.typx.Any:
         ''' Converts normalized invocables into native tool calls. '''
         raise NotImplementedError
@@ -319,7 +319,7 @@ class Model(
         selfclass,
         client: 'Client',
         name: str,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         ''' Produces model from descriptor dictionary. '''
         raise NotImplementedError
@@ -342,13 +342,13 @@ class ModelAttributes(
 ):
     ''' Attributes for all genera of AI models. '''
 
-    controls: __.AbstractSequence[ __.Control ] = ( )
+    controls: __.cabc.Sequence[ __.Control ] = ( )
 
     @classmethod
     @__.abstract_member_function
     def from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.typx.Self:
         ''' Produces model attributes from descriptor dictionary. '''
         raise NotImplementedError
@@ -356,7 +356,7 @@ class ModelAttributes(
     @classmethod
     def init_args_from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.NominativeArgumentsDictionary:
         ''' Extracts dictionary of initializer arguments from descriptor. '''
         args = __.accret.Dictionary( )
@@ -401,9 +401,9 @@ class ConverserModel(
     @__.abstract_member_function
     async def converse_v0(
         self,
-        messages: __.AbstractSequence[ __.MessageCanister ],
+        messages: __.cabc.Sequence[ __.MessageCanister ],
         supplements, # TODO: Annotate.
-        controls: __.AbstractDictionary[ str, __.Control.Instance ],
+        controls: __.cabc.Mapping[ str, __.Control.Instance ],
         reactors, # TODO: Annotate.
     ):
         ''' Interacts with model to complete a round of conversation. '''
@@ -416,7 +416,7 @@ class ConverserAttributes( ModelAttributes ):
     accepts_supervisor_instructions: bool = False
     format_preferences: _core.ConverserFormatPreferences = (
         _core.ConverserFormatPreferences( ) )
-    modalities: __.AbstractSequence[ _core.ConverserModalities ] = (
+    modalities: __.cabc.Sequence[ _core.ConverserModalities ] = (
         _core.ConverserModalities.Text, )
     supports_continuous_response: bool = False
     supports_invocations: bool = False
@@ -426,7 +426,7 @@ class ConverserAttributes( ModelAttributes ):
     @classmethod
     def init_args_from_descriptor(
         selfclass,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ) -> __.NominativeArgumentsDictionary:
         ''' Extracts dictionary of initializer arguments from descriptor. '''
         args = super( ).init_args_from_descriptor( descriptor )
@@ -475,4 +475,4 @@ class ConverserSerdeProcessor(
 
 
 # TODO: Python 3.12: Use type statement for aliases.
-ClientsByName: __.typx.TypeAlias = __.AbstractDictionary[ str, Client ]
+ClientsByName: __.typx.TypeAlias = __.cabc.Mapping[ str, Client ]

--- a/sources/aiwb/providers/preparation.py
+++ b/sources/aiwb/providers/preparation.py
@@ -28,7 +28,7 @@ from . import registries as _registries
 
 def descriptors_from_configuration(
     auxdata: __.CoreGlobals
-) -> __.AbstractSequence[ __.AbstractDictionary[ str, __.typx.Any ] ]:
+) -> __.cabc.Sequence[ __.cabc.Mapping[ str, __.typx.Any ] ]:
     ''' Validates and returns descriptors from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = [ ]
@@ -57,8 +57,8 @@ async def prepare( auxdata: __.CoreGlobals ) -> __.accret.Dictionary:
 
 async def prepare_clients(
     auxdata: __.CoreGlobals,
-    providers: __.AbstractDictionary[ str, _interfaces.Provider ],
-) -> __.AbstractDictionary[ str, _interfaces.Client ]:
+    providers: __.cabc.Mapping[ str, _interfaces.Provider ],
+) -> __.cabc.Mapping[ str, _interfaces.Client ]:
     ''' Prepares clients from configuration. '''
     # TODO: Return futures for background loading.
     #       https://docs.python.org/3/library/asyncio-future.html#asyncio.Future
@@ -87,7 +87,7 @@ async def prepare_clients(
 
 async def prepare_providers(
     auxdata: __.CoreGlobals
-) -> __.AbstractDictionary[ str, _interfaces.Provider ]:
+) -> __.cabc.Mapping[ str, _interfaces.Provider ]:
     ''' Prepares providers from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = descriptors_from_configuration( auxdata )

--- a/sources/aiwb/providers/utilities.py
+++ b/sources/aiwb/providers/utilities.py
@@ -29,7 +29,7 @@ from . import interfaces as _interfaces
 
 async def acquire_provider_configuration(
     auxdata: __.CoreGlobals, name: str
-) -> __.AbstractDictionary[ str, __.typx.Any ]:
+) -> __.cabc.Mapping[ str, __.typx.Any ]:
     ''' Returns configuration dictionary for AI provider. '''
     directory = auxdata.distribution.provide_data_location( 'providers', name )
     # TODO: Raise error if provider data directory does not exist.
@@ -86,9 +86,9 @@ async def cache_acquire_model_names(
     client: _interfaces.Client,
     acquirer: __.typx.Callable[
         [ ],
-        __.AbstractCoroutine[ __.typx.Any, __.typx.Any, __.AbstractSequence[ str ] ],
+        __.cabc.Coroutine[ __.typx.Any, __.typx.Any, __.cabc.Sequence[ str ] ],
     ],
-) -> __.AbstractSequence[ str ]:
+) -> __.cabc.Sequence[ str ]:
     ''' Acquires model names with persistent caching. '''
     # TODO? Use cache accessor from libcore.locations.
     from json import dumps, loads
@@ -132,7 +132,7 @@ def invocation_requests_from_canister(
         if ignore_invalid_canister: return [ ]
         raise Error( "Missing invocation data." ) # TODO: Better error.
     descriptors = canister.attributes.invocation_data
-    if not isinstance( descriptors, __.AbstractSequence ):
+    if not isinstance( descriptors, __.cabc.Sequence ):
         if ignore_invalid_canister: return [ ]
         raise Error( "Invocations requests is not sequence." )
     # TODO: Construct context at caller.
@@ -150,9 +150,9 @@ _models_caches = __.accret.Dictionary( )
 async def memcache_acquire_models(
     auxdata: __.CoreGlobals,
     client: _interfaces.Client,
-    genera: __.AbstractCollection[ _core.ModelGenera ],
+    genera: __.cabc.Collection[ _core.ModelGenera ],
     acquirer: __.typx.Callable, # TODO: Full signature.
-) -> __.AbstractSequence[ _interfaces.Model ]:
+) -> __.cabc.Sequence[ _interfaces.Model ]:
     ''' Caches models in memory, as necessary. '''
     provider_name = client.provider.name
     if provider_name not in _models_caches:
@@ -174,7 +174,7 @@ async def memcache_acquire_models(
         auxdata, client = client, genera = genera, acquirer = acquirer )
 
 
-_models_integrators_caches: __.AbstractDictionary[
+_models_integrators_caches: __.cabc.Mapping[
     str, _core.ModelsIntegratorsByGenusMutable
 ] = __.accret.Dictionary( )
 async def memcache_acquire_models_integrators(
@@ -198,7 +198,7 @@ async def memcache_acquire_models_integrators(
 
 async def _acquire_configuration(
     auxdata: __.CoreGlobals, directory: __.Path
-) -> __.AbstractDictionary[ str, __.typx.Any ]:
+) -> __.cabc.Mapping[ str, __.typx.Any ]:
     from tomli import loads
     files = directory.glob( '*.toml' )
     acquirers = tuple(
@@ -212,7 +212,7 @@ async def _acquire_configuration(
 
 async def _acquire_configurations(
     auxdata: __.CoreGlobals, directory: __.Path, index_name: str
-) -> __.AbstractDictionary[ str, __.typx.Any ]:
+) -> __.cabc.Mapping[ str, __.typx.Any ]:
     subdirectories = tuple(
         entity for entity in directory.rglob( f"{index_name}/*" )
         if entity.is_dir( ) )
@@ -230,7 +230,7 @@ async def _acquire_configurations(
 
 def _copy_custom_provider_configurations(
     auxdata: __.CoreGlobals, provider_name: str, index_name: str
-) -> __.AbstractSequence[ __.AbstractDictionary[ str, __.typx.Any ] ]:
+) -> __.cabc.Sequence[ __.cabc.Mapping[ str, __.typx.Any ] ]:
     factory_descriptors = (
         auxdata.configuration.get( 'provider-factories', ( ) ) )
     try:
@@ -244,9 +244,9 @@ def _copy_custom_provider_configurations(
 async def _memcache_acquire_models(
     auxdata: __.CoreGlobals,
     client: _interfaces.Client,
-    genera: __.AbstractCollection[ _core.ModelGenera ],
+    genera: __.cabc.Collection[ _core.ModelGenera ],
     acquirer: __.typx.Callable, # TODO: Full signature.
-) -> __.AbstractSequence[ _interfaces.Model ]:
+) -> __.cabc.Sequence[ _interfaces.Model ]:
     models_by_genus = _models_caches[ client.provider.name ][ client.name ]
     integrators = (
         await memcache_acquire_models_integrators(
@@ -255,7 +255,7 @@ async def _memcache_acquire_models(
     for genus in genera:
         models_by_genus[ genus ].clear( )
         for name in names:
-            descriptor: __.AbstractDictionary[ str, __.typx.Any ] = { }
+            descriptor: __.cabc.Mapping[ str, __.typx.Any ] = { }
             for integrator in integrators[ genus ]:
                 # TODO: Pass client to get variant.
                 descriptor = integrator( name, descriptor )

--- a/sources/aiwb/vectorstores/clients/chroma.py
+++ b/sources/aiwb/vectorstores/clients/chroma.py
@@ -42,7 +42,7 @@ class Factory( _core.Factory ):
     async def client_from_descriptor(
         self,
         auxdata: __.Globals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ]
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ]
     ):
         # TODO: Return future.
         # TODO? Remove dependency on Langchain.

--- a/sources/aiwb/vectorstores/clients/faiss.py
+++ b/sources/aiwb/vectorstores/clients/faiss.py
@@ -42,7 +42,7 @@ class Factory( _core.Factory ):
     async def client_from_descriptor(
         self,
         auxdata: __.Globals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ]
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ]
     ):
         # TODO: Return future.
         # TODO? Remove dependency on Langchain.

--- a/sources/aiwb/vectorstores/core.py
+++ b/sources/aiwb/vectorstores/core.py
@@ -34,7 +34,7 @@ class Factory(
     async def client_from_descriptor(
         self,
         auxdata: __.Globals,
-        descriptor: __.AbstractDictionary[ str, __.typx.Any ],
+        descriptor: __.cabc.Mapping[ str, __.typx.Any ],
     ):
         ''' Produces client from descriptor dictionary. '''
         raise NotImplementedError
@@ -59,7 +59,7 @@ def derive_vectorstores_location( auxdata: __.Globals, url: str ) -> __.Path:
 
 def descriptors_from_configuration(
     auxdata: __.Globals
-) -> __.AbstractSequence[ __.AbstractDictionary[ str, __.typx.Any ] ]:
+) -> __.cabc.Sequence[ __.cabc.Mapping[ str, __.typx.Any ] ]:
     ''' Validates and returns descriptors from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = [ ]
@@ -113,7 +113,7 @@ async def prepare_clients(
 
 async def prepare_factories(
     auxdata: __.Globals
-) -> __.AbstractDictionary[ str, Factory ]:
+) -> __.cabc.Mapping[ str, Factory ]:
     ''' Prepares factories from configuration. '''
     scribe = __.acquire_scribe( __package__ )
     descriptors = descriptors_from_configuration( auxdata )


### PR DESCRIPTION
## Summary
- use `cabc` types instead of local Abstract* aliases
- drop collections alias imports from utility module

## Testing
- `ruff check --quiet sources/aiwb/__.py` *(fails: TRY004 and TRY003)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiwb.libcore.locations.adapters.@py_builtins')*

------
https://chatgpt.com/codex/tasks/task_e_688c5b8ea3d4832ca2da6b1cee6973b8