### PR TITLE
refactor: remove helper aliases

### DIFF
--- a/sources/aiwb/__.py
+++ b/sources/aiwb/__.py
@@ -35,28 +35,15 @@ import                          os
 import                          re
 import                          types
 
-from abc import (
-    ABCMeta as ABCFactory,
-    abstractmethod as abstract_member_function,
-)
 from asyncio import (
     Lock as MutexAsync,
 )
 from collections import namedtuple # TODO: Replace with dataclass.
-from contextlib import (
-    ExitStack as            Exits,
-    AsyncExitStack as       ExitsAsync,
-    contextmanager as       exit_manager,
-    asynccontextmanager as  exit_manager_async,
-)
-from dataclasses import field as dataclass_declare
 from datetime import (
     datetime as DateTime,
     timedelta as TimeDelta,
     timezone as TimeZone,
 )
-from enum import Enum, auto as produce_enumeration_value
-from functools import partial as partial_function
 from itertools import chain
 from logging import (
     Logger as Scribe,
@@ -67,11 +54,6 @@ from pathlib import Path
 from queue import SimpleQueue
 from threading import Thread
 from time import time_ns
-from types import (
-    MappingProxyType as DictionaryProxy,
-    ModuleType as Module,
-    SimpleNamespace,
-)
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -183,7 +165,7 @@ async def read_files_async(
     else:
         def extractor( stream ): return stream.read( )
         def transformer( datum ): return deserializer( datum )
-    async with ExitsAsync( ) as exits:
+    async with ctxl.AsyncExitStack( ) as exits:
         streams = await gather_async(
             *(  exits.enter_async_context( open_( file ) )
                 for file in files ),

--- a/sources/aiwb/apiserver/cli.py
+++ b/sources/aiwb/apiserver/cli.py
@@ -45,7 +45,7 @@ class Cli( __.ApplicationCli ):
         ''' Invokes command after API server preparation. '''
         nomargs = self.prepare_invocation_args( )
         from .preparation import prepare
-        async with __.ExitsAsync( ) as exits:
+        async with __.ctxl.AsyncExitStack( ) as exits:
             auxdata = await prepare( exits = exits, **nomargs )
             await self.command( auxdata = auxdata, display = self.display )
 

--- a/sources/aiwb/apiserver/preparation.py
+++ b/sources/aiwb/apiserver/preparation.py
@@ -27,7 +27,7 @@ from . import state as _state
 
 
 async def prepare(
-    exits: __.ExitsAsync, *,
+    exits: __.ctxl.AsyncExitStack, *,
     apiserver: _server.Control = _server.Control( ),
     application: __.ApplicationInformation = __.ApplicationInformation( ),
     configedits: __.DictionaryEdits = ( ),

--- a/sources/aiwb/apiserver/server.py
+++ b/sources/aiwb/apiserver/server.py
@@ -71,7 +71,7 @@ async def prepare(
         thread = thread )
 
 
-@__.exit_manager_async
+@__.ctxl.asynccontextmanager
 async def _execute_server_thread(
     server: __.UvicornServer,
     nomargs: __.cabc.Mapping[ str, __.typx.Any ],

--- a/sources/aiwb/apiserver/state.py
+++ b/sources/aiwb/apiserver/state.py
@@ -38,5 +38,5 @@ class Globals( __.ApplicationGlobals ):
         apiserver: _server.Accessor,
     ) -> __.typx.Self:
         ''' Produces DTO from base DTO plus attribute injections. '''
-        injections = __.DictionaryProxy( dict( apiserver = apiserver ) )
+        injections = __.types.MappingProxyType( dict( apiserver = apiserver ) )
         return selfclass( **base.as_dictionary( ), **injections )

--- a/sources/aiwb/appcore/cli.py
+++ b/sources/aiwb/appcore/cli.py
@@ -35,7 +35,7 @@ class Cli( __.CoreCli ):
         ''' Invokes command after application preparation. '''
         nomargs = self.prepare_invocation_args( )
         from .preparation import prepare
-        async with __.ExitsAsync( ) as exits:
+        async with __.ctxl.AsyncExitStack( ) as exits:
             auxdata = await prepare( exits = exits, **nomargs )
             await self.command( auxdata = auxdata, display = self.display )
 
@@ -47,7 +47,7 @@ class Cli( __.CoreCli ):
         return args
 
 
-class EnablementTristate( __.Enum ): # TODO: Python 3.11: StrEnum
+class EnablementTristate( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Disable, enable, or retain the natural state? '''
 
     Disable = 'disable'
@@ -173,7 +173,7 @@ class ConfigurationModifiers( __.immut.DataclassObject ):
 class ExecuteServerCommand( metaclass = __.immut.ProtocolClass ):
     ''' Runs API server until signal. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def __call__(
         self,
         auxdata: _state.Globals,

--- a/sources/aiwb/appcore/preparation.py
+++ b/sources/aiwb/appcore/preparation.py
@@ -26,7 +26,7 @@ from . import state as _state
 
 
 async def prepare(
-    exits: __.ExitsAsync, *,
+    exits: __.ctxl.AsyncExitStack, *,
     application: __.ApplicationInformation = __.ApplicationInformation( ),
     configedits: __.DictionaryEdits = ( ),
     configfile: __.Absential[ __.Url ] = __.absent,

--- a/sources/aiwb/appcore/state.py
+++ b/sources/aiwb/appcore/state.py
@@ -29,7 +29,7 @@ class Globals( __.CoreGlobals ):
 
     # TODO: Use proper types.
     invocables: __.accret.Namespace
-    prompts: __.DictionaryProxy
+    prompts: __.types.MappingProxyType
     providers: __.accret.Dictionary
     vectorstores: dict
 
@@ -38,12 +38,12 @@ class Globals( __.CoreGlobals ):
         selfclass,
         base: __.CoreGlobals, *,
         invocables: __.accret.Namespace,
-        prompts: __.DictionaryProxy,
+        prompts: __.types.MappingProxyType,
         providers: __.accret.Dictionary,
         vectorstores: dict,
     ) -> __.typx.Self:
         ''' Produces DTO from base DTO plus attribute injections. '''
-        injections = __.DictionaryProxy( dict(
+        injections = __.types.MappingProxyType( dict(
             invocables = invocables,
             prompts = prompts,
             providers = providers,

--- a/sources/aiwb/controls/core.py
+++ b/sources/aiwb/controls/core.py
@@ -24,7 +24,7 @@
 from . import __
 
 
-class DefinitionBase( metaclass = __.ABCFactory ):
+class DefinitionBase( metaclass = __.abc.ABCMeta ):
     # TODO: Protocol class.
 
     class Instance:
@@ -46,14 +46,14 @@ class DefinitionBase( metaclass = __.ABCFactory ):
     @classmethod
     def instantiate_descriptor( class_, descriptor ):
         nomargs = descriptor.copy( )
-        nomargs[ 'attributes' ] = __.SimpleNamespace(
+        nomargs[ 'attributes' ] = __.types.SimpleNamespace(
             **( nomargs.get( 'attributes', { } ) ) )
         if 'default' not in nomargs:
             nomargs[ 'default' ] = class_.produce_default( descriptor )
         return class_( **nomargs )
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def produce_default( class_, descriptor ):
         raise NotImplementedError # TODO: Fill out error.
 
@@ -71,7 +71,7 @@ class DefinitionBase( metaclass = __.ABCFactory ):
     def deserialize( self, data ):
         return self.create_control( data )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def validate_value( self, value ):
         raise NotImplementedError # TODO: Fill out error.
 
@@ -253,7 +253,7 @@ def descriptor_to_definition( descriptor ):
 
 
 def deserialize_dictionary( definitions, dictionary ):
-    return __.DictionaryProxy( {
+    return __.types.MappingProxyType( {
         name: definitions[ name ].deserialize( data )
         for name, data in dictionary.items( ) } )
 

--- a/sources/aiwb/gui/actions.py
+++ b/sources/aiwb/gui/actions.py
@@ -300,7 +300,7 @@ async def _deduplicate_invocations(
     return tuple( sorted( deactivations, reverse = True ) )
 
 
-@__.exit_manager
+@__.ctxl.contextmanager
 def _update_conversation_progress( components, message ):
     from .updaters import update_conversation_status
     yield update_conversation_status(

--- a/sources/aiwb/gui/classes.py
+++ b/sources/aiwb/gui/classes.py
@@ -424,7 +424,7 @@ class AdaptiveTextArea( ReactiveHTML ):
 
     _style_css__ = param.String( default = '' )
 
-    _style_default__ = __.DictionaryProxy( {
+    _style_default__ = __.types.MappingProxyType( {
         'font-size': '100%',
         'resize': 'none',
     } )
@@ -533,7 +533,7 @@ class CompactSelector( ReactiveHTML ):
     value = param.String( )
     _style_css__ = param.String( )
 
-    _style_default__ = __.DictionaryProxy( {
+    _style_default__ = __.types.MappingProxyType( {
         'appearance': 'none',
         '-moz-appearance': 'none', '-webkit-appearance': 'none',
         'border-radius': '10%',
@@ -574,13 +574,13 @@ class ConversationDescriptor(
 ):
 
     identity: str = (
-        __.dataclass_declare( default_factory = lambda: __.uuid4( ).hex ) )
+        __.dcls.field( default_factory = lambda: __.uuid4( ).hex ) )
     timestamp: int = (
-        __.dataclass_declare( default_factory = __.time_ns ) )
+        __.dcls.field( default_factory = __.time_ns ) )
     title: __.typx.Optional[ str ] = None
     labels: __.cabc.MutableSequence[ str ] = (
-        __.dataclass_declare( default_factory = list ) )
-    gui: __.typx.Optional[ __.SimpleNamespace ] = None
+        __.dcls.field( default_factory = list ) )
+    gui: __.typx.Optional[ __.types.SimpleNamespace ] = None
     indicator: __.typx.Optional[ Row ] = None
 
 

--- a/sources/aiwb/gui/cli.py
+++ b/sources/aiwb/gui/cli.py
@@ -45,7 +45,7 @@ class Cli( __.ApiServerCli ):
         ''' Invokes command after GUI server preparation. '''
         nomargs = self.prepare_invocation_args( )
         from .preparation import prepare
-        async with __.ExitsAsync( ) as exits:
+        async with __.ctxl.AsyncExitStack( ) as exits:
             auxdata = await prepare( exits = exits, **nomargs )
             await self.command( auxdata = auxdata, display = self.display )
 

--- a/sources/aiwb/gui/components.py
+++ b/sources/aiwb/gui/components.py
@@ -81,7 +81,7 @@ def register_event_reactors( components, layout, component_name ):
     component = getattr( components, component_name )
     functions = entry.get( 'event_functions', { } )
     for event_name, function_name in functions.items( ):
-        function = __.partial_function(
+        function = __.funct.partial(
             getattr( registry, function_name ), components )
         if 'on_click' == event_name:
             component.on_click( function )

--- a/sources/aiwb/gui/controls.py
+++ b/sources/aiwb/gui/controls.py
@@ -24,21 +24,21 @@
 from . import __
 
 
-class ComponentManager( metaclass = __.ABCFactory ):
+class ComponentManager( metaclass = __.abc.ABCMeta ):
 
     def __init__( self, control, callback ):
         self.control = control
         self.callback = callback
         self.component = component = self._materialize( control, callback )
         component.auxdata__ = getattr(
-            component, 'auxdata__', __.SimpleNamespace( ) )
+            component, 'auxdata__', __.types.SimpleNamespace( ) )
         component.auxdata__.manager = self
 
     def assimilate( self ):
         self.control.value = self.component.value
         return self
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def _materialize( self, control, callback ):
         raise NotImplementedError
 
@@ -51,7 +51,7 @@ class ContainerManager:
             _materialize_instance( control, callback )
             for control in controls ]
         container.auxdata__ = getattr(
-            container, 'auxdata__', __.SimpleNamespace( ) )
+            container, 'auxdata__', __.types.SimpleNamespace( ) )
         container.auxdata__.manager = self
 
     def assimilate( self ):

--- a/sources/aiwb/gui/persistence.py
+++ b/sources/aiwb/gui/persistence.py
@@ -357,7 +357,7 @@ def _restore_prompt_variables_v0( gui, state, species ):
         variable = variables[ name ]
         if isinstance( variable, FlexArray ): value = [ value ]
         data[ name ] = value
-    return __.DictionaryProxy( data )
+    return __.types.MappingProxyType( data )
 
 
 def _standardize_invocation_requests_v0( canister_state ):

--- a/sources/aiwb/gui/preparation.py
+++ b/sources/aiwb/gui/preparation.py
@@ -32,14 +32,14 @@ class Manager(
 ):
     ''' Manager for GUI components and server. '''
 
-    components: __.SimpleNamespace
+    components: __.types.SimpleNamespace
     deduplicator: _updaters.UpdatesDeduplicator
     server: _server.Accessor
     transformers: __.accret.Dictionary
 
 
 async def prepare(
-    exits: __.ExitsAsync, *,
+    exits: __.ctxl.AsyncExitStack, *,
     apiserver: __.ApiServerControl = __.ApiServerControl( ),
     application: __.ApplicationInformation = __.ApplicationInformation( ),
     configedits: __.DictionaryEdits = ( ),
@@ -77,7 +77,7 @@ async def prepare(
 
 async def _prepare_components_base(
     auxdata: __.ApiServerGlobals,
-) -> __.SimpleNamespace:
+) -> __.types.SimpleNamespace:
     ''' Prepares foundation for GUI components tracker. '''
     from panel import extension
     extension( 'mathjax' )
@@ -86,7 +86,7 @@ async def _prepare_components_base(
     from .templates.default import DefaultTemplate
     template = DefaultTemplate( design = Native )
     await _prepare_favicon( auxdata, template = template )
-    return __.SimpleNamespace( template__ = template )
+    return __.types.SimpleNamespace( template__ = template )
 
 
 async def _prepare_components_complete( auxdata: _state.Globals ):

--- a/sources/aiwb/gui/server.py
+++ b/sources/aiwb/gui/server.py
@@ -27,7 +27,7 @@ from . import __
 class Accessor( __.immut.DataclassObject ):
     ''' Accessor for server properties and thread. '''
 
-    components: __.SimpleNamespace
+    components: __.types.SimpleNamespace
     control: 'Control'
 
     async def execute( self, auxdata: __.ApiServerGlobals ):
@@ -52,9 +52,9 @@ class Control( __.immut.DataclassObject ):
             address = address, port = port, reload = self.reload )
 
 
-@__.exit_manager_async
+@__.ctxl.asynccontextmanager
 async def _execute_server_thread(
-    components: __.SimpleNamespace, control: Control
+    components: __.types.SimpleNamespace, control: Control
 ) -> __.cabc.AsyncGenerator:
     scribe = __.acquire_scribe( __package__ )
     from asyncio import get_running_loop, sleep
@@ -70,7 +70,7 @@ async def _execute_server_thread(
 
 
 def _start_gui(
-    components: __.SimpleNamespace, control: Control
+    components: __.types.SimpleNamespace, control: Control
 ) -> __.typx.Any: # TODO: Proper type.
     # TODO: Honor address and port for listener socket binding.
     return components.template__.show(

--- a/sources/aiwb/gui/state.py
+++ b/sources/aiwb/gui/state.py
@@ -38,5 +38,5 @@ class Globals( __.ApiServerGlobals ):
         gui: _server.Accessor,
     ) -> __.typx.Self:
         ''' Produces DTO from base DTO plus attribute injections. '''
-        injections = __.DictionaryProxy( dict( gui = gui ) )
+        injections = __.types.MappingProxyType( dict( gui = gui ) )
         return selfclass( **base.as_dictionary( ), **injections )

--- a/sources/aiwb/gui/updaters.py
+++ b/sources/aiwb/gui/updaters.py
@@ -36,7 +36,7 @@ class UpdateRequest(
 
     updater: __.typx.Callable[ ..., __.typx.Any ]
     posargs: __.cabc.Sequence[ __.typx.Any ] = ( )
-    nomargs: __.cabc.Mapping[ str, __.typx.Any ] = __.DictionaryProxy( { } )
+    nomargs: __.cabc.Mapping[ str, __.typx.Any ] = __.types.MappingProxyType( { } )
 
     def __hash__( self ) -> int:
         return hash( (
@@ -72,13 +72,13 @@ class UpdatesDeduplicator(
     #       - Custom timeout handlers/recovery
 
     master_mutex: __.MutexAsync = (
-        __.dataclass_declare( default_factory = __.MutexAsync ) )
+        __.dcls.field( default_factory = __.MutexAsync ) )
     updates_insequent: set[ UpdateRequest ] = (
-        __.dataclass_declare( default_factory = set ) )
+        __.dcls.field( default_factory = set ) )
     updates_mutexes: dict[ UpdateRequest, __.MutexAsync ] = (
-        __.dataclass_declare( default_factory = dict ) )
+        __.dcls.field( default_factory = dict ) )
     updates_tasks: dict[ UpdateRequest, __.cabc.Coroutine ] = (
-        __.dataclass_declare( default_factory = dict ) )
+        __.dcls.field( default_factory = dict ) )
 
     async def __aenter__( self ): return self
 
@@ -112,7 +112,7 @@ class UpdatesDeduplicator(
         updater: __.typx.Callable[ ..., __.typx.Any ],
         posargs: __.cabc.Sequence[ __.typx.Any ] = ( ),
         nomargs: __.cabc.Mapping[ str, __.typx.Any ] = (
-            __.DictionaryProxy( { } ) ),
+            __.types.MappingProxyType( { } ) ),
     ) -> None:
         ''' Executes update if not already in progress. '''
         scribe = __.acquire_scribe( __package__ )
@@ -143,7 +143,7 @@ class UpdatesDeduplicator(
         updater: __.typx.Callable[ ..., __.typx.Any ],
         posargs: __.cabc.Sequence[ __.typx.Any ] = ( ),
         nomargs: __.cabc.Mapping[ str, __.typx.Any ] = (
-            __.DictionaryProxy( { } ) ),
+            __.types.MappingProxyType( { } ) ),
         delay: float = 0.1,  # seconds
     ) -> None:
         ''' Schedules update on a delay if not already in progress. '''
@@ -185,14 +185,14 @@ def add_conversation_indicator( components, descriptor, position = 0 ):
     from .classes import ConversationIndicator
     from .events import on_select_conversation
     from .layouts import conversation_indicator_layout as layout
-    container_components = __.SimpleNamespace(
+    container_components = __.types.SimpleNamespace(
         parent__ = components, identity__ = descriptor.identity )
     _components.generate( container_components, layout, 'column_indicator' )
     container_components.rehtml_indicator = indicator = (
         ConversationIndicator( container_components ) )
     container_components.text_title.object = descriptor.title
     indicator.param.watch(
-        __.partial_function( on_select_conversation, components ), 'clicked' )
+        __.funct.partial( on_select_conversation, components ), 'clicked' )
     _components.register_event_reactors(
         container_components, layout, 'column_indicator' )
     conversations = components.column_conversations_indicators
@@ -297,7 +297,7 @@ async def create_conversation( components, descriptor, state = None ):
     from .layouts import conversation_container_names
     from .persistence import inject_conversation
     # TODO: Restrict GUI namespace to conversation components.
-    components_ = __.SimpleNamespace( **components.__dict__ )
+    components_ = __.types.SimpleNamespace( **components.__dict__ )
     for component_name in conversation_container_names:
         layout = getattr( layouts, f"{component_name}_layout" )
         _components.generate( components_, layout, f"column_{component_name}" )
@@ -315,7 +315,7 @@ async def create_conversation( components, descriptor, state = None ):
 def create_message( gui, dto ):
     # TODO: Handle content arrays properly.
     layout = determine_message_layout( dto )
-    gui_ = __.SimpleNamespace(
+    gui_ = __.types.SimpleNamespace(
         canister__ = dto,
         index__ = None,
         layout__ = layout,
@@ -500,12 +500,12 @@ async def populate_prompt_variables( components, species, data = None ):
     match species:
         case 'supervisor':
             from .events import on_change_system_prompt
-            event_reactor = __.partial_function(
+            event_reactor = __.funct.partial(
                 on_change_system_prompt, components )
             postpopulator = postpopulate_system_prompt_variables
         case _: # user
             from .events import on_change_canned_prompt
-            event_reactor = __.partial_function(
+            event_reactor = __.funct.partial(
                 on_change_canned_prompt, components )
             postpopulator = postpopulate_canned_prompt_variables
     ContainerManager( row, prompt.controls.values( ), event_reactor )
@@ -793,7 +793,7 @@ def _populate_prompts_selector( gui, species ):
             and not definition.attributes.get( 'conceal', False ) ) )
     selector.options = names
     selector.auxdata__ = getattr(
-        selector, 'auxdata__', __.SimpleNamespace( prompts_cache = { } ) )
+        selector, 'auxdata__', __.types.SimpleNamespace( prompts_cache = { } ) )
 
 
 async def _update_and_save_conversation( components ):

--- a/sources/aiwb/invocables/core.py
+++ b/sources/aiwb/invocables/core.py
@@ -24,9 +24,9 @@
 from . import __
 
 
-Arguments: __.typx.TypeAlias = __.DictionaryProxy[ str, __.typx.Any ]
+Arguments: __.typx.TypeAlias = __.types.MappingProxyType[ str, __.typx.Any ]
 #Arguments = __.typx.TypeVar( 'Arguments', bound = __.pydantic.BaseModel )
-ArgumentsModel: __.typx.TypeAlias = __.DictionaryProxy[ str, __.typx.Any ]
+ArgumentsModel: __.typx.TypeAlias = __.types.MappingProxyType[ str, __.typx.Any ]
 #ArgumentsModel: __.typx.TypeAlias = type[ __.pydantic.BaseModel ]
 
 
@@ -41,11 +41,11 @@ class Deduplicator(
     arguments: __.cabc.Mapping[ str, __.typx.Any ]
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def provide_invocable_names( selfclass ) -> __.cabc.Collection[ str ]:
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def is_duplicate(
         self,
         invocable_name: str,
@@ -72,7 +72,7 @@ class Ensemble(
 
     name: str
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def prepare_invokers(
         self, auxdata: __.Globals
     ) -> __.cabc.Mapping[ str, 'Invoker' ]:
@@ -87,7 +87,7 @@ class Ensemble(
             Invoker.from_invocable(
                 ensemble = self, invocable = invocable, argschema = argschema )
             for invocable, argschema in registry )
-        return __.DictionaryProxy( {
+        return __.types.MappingProxyType( {
             invoker.name: invoker for invoker in invokers } )
 
 
@@ -177,11 +177,11 @@ async def prepare( auxdata ):
 async def prepare_ensembles( auxdata ):
     ''' Prepares ensembles of invokers from defaults and configuration. '''
     scribe = __.acquire_scribe( __package__ )
-    descriptors = __.DictionaryProxy( {
+    descriptors = __.types.MappingProxyType( {
         descriptor[ 'name' ]: descriptor
         for descriptor in descriptors_from_configuration(
             auxdata, defaults = _default_ensemble_descriptors ) } )
-    preparers_ = __.DictionaryProxy( {
+    preparers_ = __.types.MappingProxyType( {
         name: preparers[ name ]( auxdata, descriptor )
         for name, descriptor in descriptors.items( ) } )
     results = await __.gather_async(
@@ -217,16 +217,16 @@ async def prepare_invokers(
                     error, summary, scribe = scribe )
             case __.g.Value( invokers_ ):
                 invokers.update( invokers_ )
-    return __.DictionaryProxy( invokers )
+    return __.types.MappingProxyType( invokers )
 
 
-_default_ensemble_descriptors = __.DictionaryProxy( {
+_default_ensemble_descriptors = __.types.MappingProxyType( {
     'io':
-        __.DictionaryProxy( { 'name': 'io', 'enable': True } ),
+        __.types.MappingProxyType( { 'name': 'io', 'enable': True } ),
     'probability':
-        __.DictionaryProxy( { 'name': 'probability', 'enable': True } ),
+        __.types.MappingProxyType( { 'name': 'probability', 'enable': True } ),
     'summarization':
-        __.DictionaryProxy( { 'name': 'summarization', 'enable': True } ),
+        __.types.MappingProxyType( { 'name': 'summarization', 'enable': True } ),
 } )
 
 

--- a/sources/aiwb/invocables/ensembles/io/__init__.py
+++ b/sources/aiwb/invocables/ensembles/io/__init__.py
@@ -65,7 +65,7 @@ class Ensemble( __.Ensemble ):
                 in SurveyDirectoryDeduplicator.provide_invocable_names( )
                 else None )
             for invocable, argschema in _invocables ]
-        return __.DictionaryProxy( {
+        return __.types.MappingProxyType( {
             invoker.name: invoker for invoker in (
                 __.Invoker.from_invocable(
                     ensemble = self,

--- a/sources/aiwb/invocables/ensembles/io/differences.py
+++ b/sources/aiwb/invocables/ensembles/io/differences.py
@@ -24,7 +24,7 @@
 from . import __
 
 
-class DeltaType( str, __.Enum ):
+class DeltaType( str, __.enum.Enum ):
     ''' Types of partial content update operations. '''
     INSERT = 'insert'
     DELETE = 'delete'

--- a/sources/aiwb/invocables/ensembles/summarization/operations.py
+++ b/sources/aiwb/invocables/ensembles/summarization/operations.py
@@ -33,7 +33,7 @@ async def analyze(
         analysis as a list of one or more chunks, depending on size of entity
         to be analyzed.
     '''
-    operators = __.SimpleNamespace(
+    operators = __.types.SimpleNamespace(
         from_directory = _list_directory_as_cell,
         from_file = _analyze_file,
         from_http = _analyze_http,

--- a/sources/aiwb/libcore/cli.py
+++ b/sources/aiwb/libcore/cli.py
@@ -59,7 +59,7 @@ class Cli(
         ''' Invokes command after library preparation. '''
         nomargs = self.prepare_invocation_args( )
         from .preparation import prepare
-        async with __.ExitsAsync( ) as exits:
+        async with __.ctxl.AsyncExitStack( ) as exits:
             auxdata = await prepare( exits = exits, **nomargs )
             await self.command( auxdata = auxdata, display = self.display )
 
@@ -76,7 +76,7 @@ class Cli(
         return args
 
 
-class DisplayFormats( __.Enum ): # TODO: Python 3.11: StrEnum
+class DisplayFormats( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Format in which to display structured output. '''
 
     Json =      'json'
@@ -84,14 +84,14 @@ class DisplayFormats( __.Enum ): # TODO: Python 3.11: StrEnum
     Toml =      'toml'
 
 
-class DisplayStreams( __.Enum ): # TODO: Python 3.11: StrEnum
+class DisplayStreams( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Stream upon which to place output. '''
 
     Stderr =    'stderr'
     Stdout =    'stdout'
 
 
-class Inspectees( __.Enum ): # TODO: Python 3.11: StrEnum
+class Inspectees( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Facet of the application to inspect. '''
 
     Configuration =     'configuration'

--- a/sources/aiwb/libcore/dictedits.py
+++ b/sources/aiwb/libcore/dictedits.py
@@ -34,7 +34,7 @@ class Edit(
 
     address: __.cabc.Sequence[ str ]
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def __call__( self, configuration: __.cabc.MutableMapping ):
         ''' Performs edit. '''
         raise NotImplementedError

--- a/sources/aiwb/libcore/distribution.py
+++ b/sources/aiwb/libcore/distribution.py
@@ -36,7 +36,7 @@ class Information(
 
     @classmethod
     async def prepare(
-        selfclass, package: str, exits: __.ExitsAsync
+        selfclass, package: str, exits: __.ctxl.AsyncExitStack
     ) -> __.typx.Self:
         ''' Acquires information about our package distribution. '''
         from importlib.metadata import packages_distributions

--- a/sources/aiwb/libcore/inscription.py
+++ b/sources/aiwb/libcore/inscription.py
@@ -25,7 +25,7 @@ from . import __
 from . import state as _state
 
 
-class Modes( __.Enum ): # TODO: Python 3.11: StrEnum
+class Modes( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Possible modes for logging output. '''
 
     Null = 'null' # suppress library logs

--- a/sources/aiwb/libcore/locations/adapters/aiofiles.py
+++ b/sources/aiwb/libcore/locations/adapters/aiofiles.py
@@ -91,7 +91,7 @@ class _Common( __.AdapterBase ):
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         pursue_indirection: bool = True,
     ) -> __.Inode:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationExamineFailure, url = self.url )
         try:
             from os.path import realpath
@@ -138,7 +138,7 @@ class GeneralAdapter( _Common, __.GeneralAdapter ):
         pursue_indirection: bool = True,
         species: __.Absential[ __.LocationSpecies ] = __.absent,
     ) -> __.SpecificAdapter:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAccessorDerivationFailure,
             entity_name = _entity_name, url = self.url )
         try:
@@ -205,7 +205,7 @@ class DirectoryAdapter( _Common, __.DirectoryAdapter ):
             raise __.LocationCreateFailure(
                 url = self.url, reason = str( exc ) ) from exc
         url = accessor.as_url( )
-        Error = __.partial_function( __.LocationCreateFailure, url = url )
+        Error = __.funct.partial( __.LocationCreateFailure, url = url )
         exists = await _probe_accessor_if_exists(
             accessor,
             species = __.LocationSpecies.Directory,
@@ -236,7 +236,7 @@ class DirectoryAdapter( _Common, __.DirectoryAdapter ):
             raise __.LocationCreateFailure(
                 url = self.url, reason = str( exc ) ) from exc
         url = accessor.as_url( )
-        Error = __.partial_function( __.LocationCreateFailure, url = url )
+        Error = __.funct.partial( __.LocationCreateFailure, url = url )
         exists = await _probe_accessor_if_exists(
             accessor,
             species = __.LocationSpecies.File,
@@ -338,7 +338,7 @@ class FileAdapter( _Common, __.FileAdapter ):
     async def acquire_content_result(
         self, attributes: __.InodeAttributes = __.InodeAttributes.Nothing
     ) -> __.AcquireContentBytesResult:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAcquireContentFailure, url = self.url )
         try:
             from os import fstat
@@ -361,7 +361,7 @@ class FileAdapter( _Common, __.FileAdapter ):
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         options: __.FileUpdateOptions = __.FileUpdateOptions.Defaults,
     ) -> __.Inode:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationUpdateContentFailure, url = self.url )
         flags = _flags_from_file_update_options( options )
         await _create_parent_directories(

--- a/sources/aiwb/libcore/locations/adapters/httpx.py
+++ b/sources/aiwb/libcore/locations/adapters/httpx.py
@@ -57,7 +57,7 @@ class _Common( __.AdapterBase ):
         permissions: __.Permissions,
         pursue_indirection: bool = True,
     ) -> bool:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationCheckAccessFailure, url = self.url )
         try:
             inode = await self._inspect_permissions(
@@ -96,7 +96,7 @@ class _Common( __.AdapterBase ):
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         pursue_indirection: bool = True,
     ) -> __.Inode:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationExamineFailure, url = self.url )
         try:
             inode = await self._inspect_permissions(
@@ -145,7 +145,7 @@ class GeneralAdapter( _Common, __.GeneralAdapter ):
         return selfclass( url = __.Url.from_url( url ) )
 
     def as_directory( self ) -> '__.DirectoryAdapter':
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAccessorDerivationFailure,
             entity_name = _entity_name, url = self.url )
         reason = "No derivative available for directory."
@@ -160,7 +160,7 @@ class GeneralAdapter( _Common, __.GeneralAdapter ):
         pursue_indirection: bool = True,
         species: __.Absential[ __.LocationSpecies ] = __.absent,
     ) -> __.SpecificAdapter:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAccessorDerivationFailure,
             entity_name = _entity_name, url = self.url )
         try:
@@ -201,7 +201,7 @@ class FileAdapter( _Common, __.FileAdapter ):
     async def acquire_content_result(
         self, attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
     ) -> __.AcquireContentBytesResult:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAcquireContentFailure, url = self.url )
         async with _httpx.AsyncClient( ) as client:
             response = await client.get( self.implement )
@@ -226,7 +226,7 @@ class FileAdapter( _Common, __.FileAdapter ):
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         options: __.FileUpdateOptions = __.FileUpdateOptions.Defaults,
     ) -> __.Inode:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationUpdateContentFailure, url = self.url )
         try: inode_ = await self._examine( )
         except Exception as exc: raise Error( reason = str( exc ) ) from exc
@@ -292,7 +292,7 @@ def _headers_from_file_update_options(
             start, end = size, size + delta - 1
             size_new = size + delta
             headers[ 'Content-Range' ] = f"bytes {start}-{end}/{size_new}"
-    return __.DictionaryProxy( headers )
+    return __.types.MappingProxyType( headers )
 
 
 def _inode_from_headers(

--- a/sources/aiwb/libcore/locations/caches/simple.py
+++ b/sources/aiwb/libcore/locations/caches/simple.py
@@ -98,12 +98,12 @@ class _Common( __.CacheBase, __.typx.Protocol ):
     def expose_implement( self ) -> __.AccessImplement:
         return self.adapter.expose_implement( )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def _ingest( self ):
         raise NotImplementedError
 
     async def _ingest_if_absent( self ):
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationCacheIngestFailure,
             source_url = self.adapter.as_url( ), cache_url = self.cache_url )
         cache_adapter = __.adapter_from_url( self.cache_url )
@@ -217,7 +217,7 @@ class GeneralCache( _Common, __.GeneralCache ):
         pursue_indirection: bool = True,
         species: __.Absential[ __.LocationSpecies ] = __.absent,
     ) -> '__.SpecificCache':
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAccessorDerivationFailure,
             entity_name = _entity_name, url = self.cache_url )
         try:
@@ -259,7 +259,7 @@ class GeneralCache( _Common, __.GeneralCache ):
         return await cache_adapter.is_indirection( )
 
     async def _ingest( self ):
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationCacheIngestFailure,
             source_url = self.adapter.as_url( ), cache_url = self.cache_url )
         try: adapter = await self.adapter.as_specific( )
@@ -370,7 +370,7 @@ class DirectoryCache( _Common, __.DirectoryCache ):
             attributes = attributes, filters = filters, recurse = recurse )
 
     async def _ingest( self ):
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationCacheIngestFailure,
             source_url = self.adapter.as_url( ), cache_url = self.cache_url )
         cache_adapter = __.adapter_from_url( self.cache_url )
@@ -427,7 +427,7 @@ class FileCache( _Common, __.FileCache ):
             content, attributes = attributes, options = options )
 
     async def _ingest( self ):
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationCacheIngestFailure,
             source_url = self.adapter.as_url( ), cache_url = self.cache_url )
         try:

--- a/sources/aiwb/libcore/locations/core.py
+++ b/sources/aiwb/libcore/locations/core.py
@@ -27,14 +27,14 @@ from . import __
 
 
 # TODO: Replace with type variable for generics.
-class AccessImplement( metaclass = __.ABCFactory ):
+class AccessImplement( metaclass = __.abc.ABCMeta ):
     ''' Abstract base class for location access implements. '''
     # Note: Not a Protocol class because there is no common protocol.
     #       We just want issubclass support.
     #       Functions which return implements should cast.
 
 
-class AdapterInode( metaclass = __.ABCFactory ):
+class AdapterInode( metaclass = __.abc.ABCMeta ):
     ''' Abstract base class for adapter-specific location information. '''
     # Note: Not a Protocol class because there is no common protocol.
     #       We just want issubclass support.
@@ -62,7 +62,7 @@ class AcquireContentTextResult( AcquireContentResult ):
     content: str
 
 
-class AlienResolutionActions( __.Enum ): # TODO: Python 3.11: StrEnum
+class AlienResolutionActions( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Which action to take when unregistered cache entity is encountered.
 
         Simple caches might not have the concept of aliens. However, they are
@@ -96,7 +96,7 @@ class CacheDifferenceBase:
     #   InodeCacheDifference (bytes_count, content_id, mtime, species, etc...)
 
 
-class ConflictResolutionActions( __.Enum ): # TODO: Python 3.11: StrEnum
+class ConflictResolutionActions( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Which action to take upon conflict between cache and sources.
 
         Custom behaviors should be specified on cache manager initialization or
@@ -140,11 +140,11 @@ class FileUpdateOptions( __.enum.IntFlag ):
     ''' File update options bits. '''
 
     Defaults = 0  # create (if not exists), truncate
-    Append = __.produce_enumeration_value( ) # append
-    Absence = __.produce_enumeration_value( ) # error (if exists)
+    Append = __.enum.auto( ) # append
+    Absence = __.enum.auto( ) # error (if exists)
 
 
-class ImpurityResolutionActions( __.Enum ): # TODO: Python 3.11: StrEnum
+class ImpurityResolutionActions( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Which action to take when cache has unregistered alterations.
 
         Simple caches might not have the concept of impurities. However, they
@@ -230,15 +230,15 @@ class InodeAttributes( __.enum.IntFlag ):
     ''' Which nullable attributes to fill when requesting an inode. '''
 
     Nothing = 0
-    BytesCount = __.produce_enumeration_value( )
-    ContentId = __.produce_enumeration_value( )
-    Mimetype = __.produce_enumeration_value( )
-    Charset = __.produce_enumeration_value( )
-    Mtime = __.produce_enumeration_value( ) # modification time
-    Etime = __.produce_enumeration_value( ) # expiration time
+    BytesCount = __.enum.auto( )
+    ContentId = __.enum.auto( )
+    Mimetype = __.enum.auto( )
+    Charset = __.enum.auto( )
+    Mtime = __.enum.auto( ) # modification time
+    Etime = __.enum.auto( ) # expiration time
 
 
-class LocationSpecies( __.Enum ): # TODO: Python 3.11: StrEnum
+class LocationSpecies( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Species of entity at location. '''
     # TODO? Solaris doors, etc...
 
@@ -256,18 +256,18 @@ class Permissions( __.enum.IntFlag ):
     ''' Permissions bits to report or test access. '''
 
     Abstain = 0
-    Retrieve = __.produce_enumeration_value( )
-    Create = __.produce_enumeration_value( )
-    Update = __.produce_enumeration_value( )
-    Delete = __.produce_enumeration_value( )
-    Execute = __.produce_enumeration_value( )
+    Retrieve = __.enum.auto( )
+    Create = __.enum.auto( )
+    Update = __.enum.auto( )
+    Delete = __.enum.auto( )
+    Execute = __.enum.auto( )
 
 Permissions_CUD = Permissions.Create | Permissions.Update | Permissions.Delete
 Permissions_RCUD = Permissions_CUD | Permissions.Retrieve
 Permissions_RCUDX = Permissions_RCUD | Permissions.Execute
 
 
-class Possessor( __.Enum ):
+class Possessor( __.enum.Enum ):
     ''' Representation of potential owner of location. '''
 
     CurrentUser = 'current user'

--- a/sources/aiwb/libcore/locations/filters/vcs.py
+++ b/sources/aiwb/libcore/locations/filters/vcs.py
@@ -24,7 +24,7 @@
 from . import __
 
 
-_names = __.DictionaryProxy( {
+_names = __.types.MappingProxyType( {
     'BitKeeper':    'bk',
     'Bazaar':       'bzr',
     'CVS':          'cvs',

--- a/sources/aiwb/libcore/locations/interfaces.py
+++ b/sources/aiwb/libcore/locations/interfaces.py
@@ -42,12 +42,12 @@ class _Common(
 
     def __str__( self ) -> str: return str( self.as_url( ) )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def as_url( self ) -> _core.Url:
         ''' Returns URL associated with location. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def check_access(
         self,
         permissions: _core.Permissions,
@@ -56,14 +56,14 @@ class _Common(
         ''' Does current process have access to location? '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def check_existence(
         self, pursue_indirection: bool = True
     ) -> bool:
         ''' Does location exist? '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def examine(
         self,
         attributes: _core.InodeAttributes = _core.InodeAttributes.Nothing,
@@ -72,7 +72,7 @@ class _Common(
         ''' Returns inode-like object for location. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def expose_implement( self ) -> _core.AccessImplement:
         ''' Exposes concrete implement used to perform operations. '''
         raise NotImplementedError
@@ -87,7 +87,7 @@ class AdapterBase(
     ''' Common functionality for all access adapters. '''
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def is_cache_manager( selfclass ) -> bool:
         ''' Is access adapter a cache manager for itself?
 
@@ -106,7 +106,7 @@ class CacheBase(
 class Filter( __.typx.Protocol ):
     ''' Determines if directory entry should be filtered. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def __call__( self, dirent: _core.DirectoryEntry ) -> bool:
         raise NotImplementedError
 
@@ -118,7 +118,7 @@ class DirectoryOperations(
 ):
     ''' Standard operations on directories. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def create_directory(
         self,
         name: 'PossibleRelativeLocator',
@@ -129,7 +129,7 @@ class DirectoryOperations(
         ''' Creates directory relative to URL of this accessor. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def create_file(
         self,
         name: 'PossibleRelativeLocator',
@@ -142,7 +142,7 @@ class DirectoryOperations(
 
     # TODO: create_indirection
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def delete_directory(
         self,
         name: 'PossibleRelativeLocator',
@@ -153,7 +153,7 @@ class DirectoryOperations(
         ''' Deletes directory relative to URL of this accessor. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def delete_file(
         self,
         name: 'PossibleRelativeLocator',
@@ -164,14 +164,14 @@ class DirectoryOperations(
 
     # TODO: delete_indirection
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def produce_entry_accessor(
         self, name: 'PossibleRelativeLocator'
     ) -> 'GeneralAccessor':
         ''' Derives new accessor relative to URL of this accessor. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def survey_entries(
         self,
         attributes: _core.InodeAttributes = _core.InodeAttributes.Nothing,
@@ -191,7 +191,7 @@ class FileOperations(
 ):
     ''' Standard operations on files. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def acquire_content( self ) -> bytes:
         ''' Returns content of file as raw bytes. '''
         raise NotImplementedError
@@ -199,7 +199,7 @@ class FileOperations(
     # TODO: acquire_content_continuous
     #       Returns iterator which has inode attribute.
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def acquire_content_result(
         self,
         attributes: _core.InodeAttributes = _core.InodeAttributes.Nothing,
@@ -207,7 +207,7 @@ class FileOperations(
         ''' Returns inode and content of file as raw bytes. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def update_content(
         self,
         content: bytes,
@@ -227,7 +227,7 @@ class GeneralOperations(
 ):
     ''' Standard operations on locations of indeterminate species. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def as_directory( self ) -> 'DirectoryAccessor':
         ''' Returns directory accessor without sanity checks.
 
@@ -235,7 +235,7 @@ class GeneralOperations(
         '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def as_file( self ) -> 'FileAccessor':
         ''' Returns file accessor without sanity checks.
 
@@ -243,7 +243,7 @@ class GeneralOperations(
         '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def as_specific(
         self,
         force: bool = False,
@@ -259,7 +259,7 @@ class GeneralOperations(
         species: __.Absential[ _core.LocationSpecies ] = __.absent,
     ) -> _core.LocationSpecies:
         ''' Discovers or asserts species of location. '''
-        Error = __.partial_function(
+        Error = __.funct.partial(
             _exceptions.LocationSpeciesAssertionError, url = self.as_url( ) )
         try:
             species_ = (
@@ -275,17 +275,17 @@ class GeneralOperations(
             return species_
         return species
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def is_directory( self, pursue_indirection: bool = True ) -> bool:
         ''' Is location a directory? '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def is_file( self, pursue_indirection: bool = True ) -> bool:
         ''' Is location a regular file? '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def is_indirection( self ) -> bool:
         ''' Does location provide indirection to another location? '''
         raise NotImplementedError
@@ -304,7 +304,7 @@ class ReconciliationOperations(
 
     # TODO? clear
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def commit(
         self, *,
         aliens: _core.AlienResolutionActions
@@ -317,19 +317,19 @@ class ReconciliationOperations(
         ''' Commits cache to sources. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def difference(
         self
     ) -> __.cabc.Sequence[ _core.CacheDifferenceBase ]:
         ''' Reports differences between cache and sources. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def is_divergent( self ) -> bool:
         ''' Checks if cache matches sources. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def reingest(
         self, *,
         aliens: _core.AlienResolutionActions
@@ -364,7 +364,7 @@ class GeneralAdapter(
     ''' General location access adapter. '''
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def from_url( selfclass, url: _core.PossibleUrl ) -> __.typx.Self:
         ''' Produces adapter from URL. '''
         raise NotImplementedError
@@ -381,17 +381,17 @@ class CacheManager(
     # TODO: Immutable instance attributes.
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def from_url( selfclass, url: _core.PossibleUrl ) -> __.typx.Self:
         ''' Produces cache manager from storage location URL. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def as_url( self ) -> _core.Url:
         ''' Returns URL associated with cache storage location. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def produce_cache( self, adapter: 'GeneralAdapter' ) -> 'GeneralCache':
         ''' Produces cache from general location access adapter. '''
         raise NotImplementedError
@@ -418,7 +418,7 @@ class GeneralCache(
     ''' General location cache. '''
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def from_url( selfclass, url: _core.PossibleUrl ) -> __.typx.Self:
         ''' Produces cache from URL. '''
         raise NotImplementedError
@@ -432,7 +432,7 @@ class FilePresenter(
 
     accessor: 'FileAccessor'
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def acquire_content( self ) -> __.typx.Any:
         ''' Returns content of file as specific type. '''
         raise NotImplementedError
@@ -440,7 +440,7 @@ class FilePresenter(
     # TODO: acquire_content_continuous
     #       Returns iterator which has inode attribute.
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def acquire_content_result(
         self, *,
         attributes: _core.InodeAttributes = _core.InodeAttributes.Nothing,
@@ -448,7 +448,7 @@ class FilePresenter(
         ''' Returns inode and content of file as specific type. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def update_content(
         self,
         content: __.typx.Any,

--- a/sources/aiwb/libcore/locations/presenters/text.py
+++ b/sources/aiwb/libcore/locations/presenters/text.py
@@ -42,7 +42,7 @@ class FilePresenter( __.FilePresenter ):
         self, *,
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
     ) -> __.AcquireContentTextResult:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationAcquireContentFailure, url = self.accessor.as_url( ) )
         attributes |= __.InodeAttributes.Mimetype
         if '#DETECT#' == self.charset:
@@ -75,7 +75,7 @@ class FilePresenter( __.FilePresenter ):
         attributes: __.InodeAttributes = __.InodeAttributes.Nothing,
         options: __.FileUpdateOptions = __.FileUpdateOptions.Defaults,
     ) -> __.Inode:
-        Error = __.partial_function(
+        Error = __.funct.partial(
             __.LocationUpdateContentFailure, url = self.accessor.as_url( ) )
         content_nl = self._nativize_newlines( content )
         # Charset detection is meaningless for output.

--- a/sources/aiwb/libcore/notifications.py
+++ b/sources/aiwb/libcore/notifications.py
@@ -47,7 +47,7 @@ class Queue( __.immut.DataclassObject ):
     ''' Queue for notifications to be consumed by application. '''
 
     # TODO: Hide queue attribute.
-    queue: __.SimpleQueue = __.dataclass_declare(
+    queue: __.SimpleQueue = __.dcls.field(
         default_factory = __.SimpleQueue )
 
     # TODO? enqueue_admonition
@@ -91,7 +91,7 @@ class Queue( __.immut.DataclassObject ):
 
     # TODO: enqueue_future
 
-    @__.exit_manager
+    @__.ctxl.contextmanager
     def enqueue_on_error(
         self,
         summary: str, *,

--- a/sources/aiwb/libcore/preparation.py
+++ b/sources/aiwb/libcore/preparation.py
@@ -34,7 +34,7 @@ from . import state as _state
 
 
 async def prepare(
-    exits: __.ExitsAsync,
+    exits: __.ctxl.AsyncExitStack,
     application: _application.Information = _application.Information( ),
     configedits: _dictedits.Edits = ( ),
     configfile: __.Absential[ _locations.Url ] = __.absent,

--- a/sources/aiwb/libcore/state.py
+++ b/sources/aiwb/libcore/state.py
@@ -27,7 +27,7 @@ from . import distribution as _distribution
 from . import notifications as _notifications
 
 
-class DirectorySpecies( __.Enum ): # TODO: Python 3.11: StrEnum
+class DirectorySpecies( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Possible species for locations. '''
 
     Cache = 'cache'
@@ -44,7 +44,7 @@ class Globals(
     configuration: __.accret.Dictionary
     directories: __.PlatformDirs
     distribution: _distribution.Information
-    exits: __.ExitsAsync # TODO? Make accretive.
+    exits: __.ctxl.AsyncExitStack # TODO? Make accretive.
     notifications: _notifications.Queue
 
     def as_dictionary( self ) -> __.cabc.Mapping[ str, __.typx.Any ]:

--- a/sources/aiwb/messages/core.py
+++ b/sources/aiwb/messages/core.py
@@ -29,7 +29,7 @@ class DirectoryManager( __.immut.DataclassObject ):
 
     auxdata: __.accret.Namespace
 
-    _mkdir_nomargs_default = __.DictionaryProxy( dict(
+    _mkdir_nomargs_default = __.types.MappingProxyType( dict(
         exist_ok = True, parents = True ) )
 
     def assert_content_directory( self, identity ):
@@ -71,7 +71,7 @@ class Content(
 ):
     ''' Base for various content types. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def save( self, manager: DirectoryManager ):
         ''' Persists content to durable storage. '''
         raise NotImplementedError
@@ -82,9 +82,9 @@ class TextualContent( Content ):
 
     data: str
     identity: str = (
-        __.dataclass_declare( default_factory = lambda: __.uuid4( ).hex ) )
+        __.dcls.field( default_factory = lambda: __.uuid4( ).hex ) )
     timestamp: int = (
-        __.dataclass_declare( default_factory = __.time_ns ) )
+        __.dcls.field( default_factory = __.time_ns ) )
     mimetype: str = 'text/markdown'
 
     async def save( self, manager: DirectoryManager ):
@@ -110,7 +110,7 @@ class TextualContent( Content ):
 # TODO: PictureContent
 
 
-class Role( __.Enum ): # TODO: Python 3.11: StrEnum
+class Role( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Platform-neutral role of conversation message.
 
         Implementations must map these roles to their native roles or
@@ -147,10 +147,10 @@ class Canister(
 ):
     ''' Message canister which can have multiple contents. '''
 
-    attributes: __.SimpleNamespace = (
-        __.dataclass_declare( default_factory = __.SimpleNamespace ) )
+    attributes: __.types.SimpleNamespace = (
+        __.dcls.field( default_factory = __.types.SimpleNamespace ) )
     contents: __.cabc.MutableSequence[ Content ] = (
-        __.dataclass_declare( default_factory = list ) )
+        __.dcls.field( default_factory = list ) )
 
     def add_content( self, data, /, **descriptor ):
         ''' Adds content of appropriate type to canister. '''
@@ -175,7 +175,7 @@ class Canister(
     def __len__( self ): return len( self.contents )
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def role( self ) -> Role:
         ''' Corresponding message role for canister. '''
 
@@ -281,7 +281,7 @@ async def restore_canister( manager, canister_state ):
             attributes[ 'invocation_data' ] = loads( invocation_data )
     if attributes:
         # TODO? Convert hyphenated keys to underscored.
-        nomargs[ 'attributes' ] = __.SimpleNamespace( **attributes )
+        nomargs[ 'attributes' ] = __.types.SimpleNamespace( **attributes )
     canister = role.produce_canister( **nomargs )
     for content in contents: canister.contents.append( content )
     return canister

--- a/sources/aiwb/prompts/core.py
+++ b/sources/aiwb/prompts/core.py
@@ -114,7 +114,7 @@ class Store(
                 user_home = __.Path.home( ) ) ).expose_implement( )
         return __.accret.Dictionary( name = name, location = location )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def acquire_definitions(
         self,
         auxdata: __.Globals,
@@ -145,7 +145,7 @@ async def acquire_definitions(
                     error, summary, scribe = scribe )
             case __.g.Value( definitions_ ):
                 definitions.update( definitions_ )
-    return __.DictionaryProxy( definitions )
+    return __.types.MappingProxyType( definitions )
 
 
 async def acquire_stores(
@@ -169,7 +169,7 @@ async def acquire_stores(
                     error, summary, details = descriptor, scribe = scribe )
             case __.g.Value( store ):
                 stores[ store.name ] = store
-    return __.DictionaryProxy( stores )
+    return __.types.MappingProxyType( stores )
 
 
 def descriptors_from_configuration(

--- a/sources/aiwb/prompts/flavors/native.py
+++ b/sources/aiwb/prompts/flavors/native.py
@@ -41,7 +41,7 @@ class Definition( _core.Definition ):
         ):
             super( ).__init__( definition )
             values = values or { }
-            self.controls = __.DictionaryProxy( {
+            self.controls = __.types.MappingProxyType( {
                 name: (
                     variable.create_control( values[ name ] )
                     if name in values else variable.create_control_default( ) )
@@ -78,10 +78,10 @@ class Definition( _core.Definition ):
         super( ).__init__( location, name )
         self.species = species
         self.templates = templates # TODO: Validate.
-        self.attributes = attributes or __.DictionaryProxy( { } )
+        self.attributes = attributes or __.types.MappingProxyType( { } )
         # TODO: Validate fragments. Bucket by MIME type?
         self.fragments = fragments or { }
-        self.variables = __.DictionaryProxy( {
+        self.variables = __.types.MappingProxyType( {
             variable[ 'name' ]: descriptor_to_definition( variable )
             for variable in variables } )
 
@@ -100,7 +100,7 @@ class Store( _core.Store ):
         # TODO: Rename 'descriptors' to 'definitions'.
         location = location / 'descriptors'
         files = tuple( location.resolve( strict = True ).glob( '*.toml' ) )
-        deserializer = __.partial_function(
+        deserializer = __.funct.partial(
             _deserialize_definition_data, store = self )
         results = await __.read_files_async(
             *files, deserializer = deserializer, return_exceptions = True )
@@ -113,7 +113,7 @@ class Store( _core.Store ):
                         error, summary, scribe = scribe )
                 case __.g.Value( definition ):
                     definitions[ definition.name ] = definition
-        return __.DictionaryProxy( definitions )
+        return __.types.MappingProxyType( definitions )
 
 _core.flavors[ 'native' ] = Store
 

--- a/sources/aiwb/providers/clients/anthropic/clients.py
+++ b/sources/aiwb/providers/clients/anthropic/clients.py
@@ -41,7 +41,7 @@ _model_genera = frozenset( (
 ) )
 
 
-class ProviderVariants( __.Enum ):
+class ProviderVariants( __.enum.Enum ):
     ''' Anthropic provider variants. '''
 
     Anthropic =     'anthropic'
@@ -91,11 +91,11 @@ class Client( __.Client ):
             auxdata,
             client = self,
             genera = genera,
-            acquirer = __.partial_function(
+            acquirer = __.funct.partial(
                 __.cache_acquire_model_names,
                 acquirer = self._acquire_model_names ) )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         ''' Acquires model names from API or other source. '''
         raise NotImplementedError
@@ -170,7 +170,7 @@ class Provider( __.Provider ):
 # https://docs.anthropic.com/en/docs/about-claude/models
 # https://docs.anthropic.com/en/docs/resources/model-deprecations
 # TODO: Move lists of models to providers data.
-_model_names = __.DictionaryProxy( {
+_model_names = __.types.MappingProxyType( {
     ProviderVariants.Anthropic: (
         'claude-2.0',
         'claude-2.1',

--- a/sources/aiwb/providers/clients/anthropic/conversers.py
+++ b/sources/aiwb/providers/clients/anthropic/conversers.py
@@ -36,7 +36,7 @@ AttributesDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 ModelDescriptor: __.typx.TypeAlias = __.cabc.Mapping[ str, __.typx.Any ]
 
 
-class NativeMessageRefinementActions( __.Enum ): # TODO: Python 3.11: StrEnum
+class NativeMessageRefinementActions( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Which action to perform on native message under refinement cursor. '''
 
     Retain      = 'retain'
@@ -347,7 +347,7 @@ def _append_user_cache_control_watermarks(
 
 def _canister_from_response_element( model, element ):
     # TODO: Appropriate error classes.
-    attributes = __.SimpleNamespace(
+    attributes = __.types.SimpleNamespace(
         behaviors = [ ],
         model_context = {
             'provider': model.provider.name,
@@ -402,7 +402,7 @@ def _collect_supervisor_instructions(
 async def _converse_complete_v0(
     model: Model, arguments: dict[ str, __.typx.Any ], reactors
 ): # TODO: return signature
-    error = __.partial_function(
+    error = __.funct.partial(
         __.ModelOperateFailure, model = model, operation = 'chat completion' )
     client = model.client.produce_implement( )
     from anthropic import AnthropicError
@@ -414,7 +414,7 @@ async def _converse_complete_v0(
 async def _converse_continuous_v0(
     model: Model, arguments: dict[ str, __.typx.Any ], reactors
 ): # TODO: return signature
-    error = __.partial_function(
+    error = __.funct.partial(
         __.ModelOperateFailure, model = model, operation = 'chat completion' )
     client = model.client.produce_implement( )
     from anthropic import AnthropicError

--- a/sources/aiwb/providers/clients/openai/clients.py
+++ b/sources/aiwb/providers/clients/openai/clients.py
@@ -41,7 +41,7 @@ _model_genera = frozenset( (
 ) )
 
 
-class ProviderVariants( __.Enum ):
+class ProviderVariants( __.enum.Enum ):
     ''' OpenAI client variants. '''
 
     OpenAi =            'openai'
@@ -90,11 +90,11 @@ class Client( __.Client ):
             auxdata,
             client = self,
             genera = genera,
-            acquirer = __.partial_function(
+            acquirer = __.funct.partial(
                 __.cache_acquire_model_names,
                 acquirer = self._acquire_model_names ) )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def _acquire_model_names( self ) -> __.cabc.Sequence[ str ]:
         ''' Acquires model names from API or other source. '''
         raise NotImplementedError

--- a/sources/aiwb/providers/clients/openai/conversers.py
+++ b/sources/aiwb/providers/clients/openai/conversers.py
@@ -32,21 +32,21 @@ OpenAiMessage: __.typx.TypeAlias = dict[ str, __.typx.Any ]
 OpenAiMessageContent: __.typx.TypeAlias = str | list[ dict[ str, __.typx.Any ] ]
 
 
-class InvocationsSupportLevels( __.Enum ): # TODO: Python 3.11: StrEnum
+class InvocationsSupportLevels( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Degree to which invocations are supported. '''
 
     Single      = 'single'      # Mid-2023.
     Concurrent  = 'concurrent'  # Late 2023 and beyond.
 
 
-class NativeMessageRefinementActions( __.Enum ): # TODO: Python 3.11: StrEnum
+class NativeMessageRefinementActions( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Which action to perform on native message under refinement cursor. '''
 
     Retain      = 'retain'
     Merge       = 'merge'
 
 
-class NativeSupervisorRoles( __.Enum ):
+class NativeSupervisorRoles( __.enum.Enum ):
     ''' Which role to use for supervisor instructions. '''
 
     System      = 'system'      # Default.
@@ -383,7 +383,7 @@ def _canister_from_response_element( model, element ):
     # TODO: Appropriate error classes.
     if ( delta := hasattr( element, 'delta' ) ): message = element.delta
     else: message = element.message
-    attributes = __.SimpleNamespace(
+    attributes = __.types.SimpleNamespace(
         behaviors = [ ],
         model_context = {
             'provider': model.provider.name,

--- a/sources/aiwb/providers/core.py
+++ b/sources/aiwb/providers/core.py
@@ -98,7 +98,7 @@ class ConversationReactors( __.immut.DataclassObject ):
         lambda handle: None )
 
 
-class DataFormatPreferences( __.Enum ): # TODO: Python 3.11: StrEnum
+class DataFormatPreferences( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Preferred data formats for AI model input or output. '''
 
     Indefinite =    '#indefinite#'
@@ -106,21 +106,21 @@ class DataFormatPreferences( __.Enum ): # TODO: Python 3.11: StrEnum
     XML =           'XML'
 
 
-class MathFormatPreferences( __.Enum ): # TODO: Python 3.11: StrEnum
+class MathFormatPreferences( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Preferred math expression formats for AI model input or output. '''
 
     Indefinite =    '#indefinite#'
     MathJax =       'MathJax' # $$ .. $$, \[ .. \], \( .. \)
 
 
-class TextFormatPreferences( __.Enum ): # TODO: Python 3.11: StrEnum
+class TextFormatPreferences( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Preferred text prose formats for AI model input or output. '''
 
     Indefinite =    '#indefinite#'
     Markdown =      'Markdown'
 
 
-class ConverserModalities( __.Enum ): # TODO: Python 3.11: StrEnum
+class ConverserModalities( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Supportable input modalities for AI chat models. '''
 
     Audio       = 'audio'
@@ -192,7 +192,7 @@ class InvocationRequest(
     arguments: __.cabc.Mapping[ str, __.typx.Any ]
     invocation: __.typx.Callable # TODO: Full signature.
     specifics: __.accret.Dictionary = ( # TODO: Full signature.
-        __.dataclass_declare( default_factory = __.accret.Dictionary ) )
+        __.dcls.field( default_factory = __.accret.Dictionary ) )
 
     @classmethod
     def from_descriptor(
@@ -211,7 +211,7 @@ class InvocationRequest(
             raise Error( f"Invocable {name!r} is not available." )
         arguments = descriptor.get( 'arguments', { } )
         # TODO: Provide supplements based on specification from invocable.
-        invocation = __.partial_function(
+        invocation = __.funct.partial(
             context.invokers[ name ],
             auxdata = context.auxdata,
             arguments = arguments,
@@ -225,7 +225,7 @@ class ModelIntegrationBehaviors( __.enum.IntFlag ):
     # TODO: Immutable class attributes.
 
     Default             = 0
-    ReplaceControls     = __.produce_enumeration_value( )
+    ReplaceControls     = __.enum.auto( )
 
 
 class ModelsIntegrator(
@@ -249,7 +249,7 @@ class ModelsIntegrator(
         behaviors = ModelIntegrationBehaviors.Default
         if desc.pop( 'replaces-controls', False ):
             behaviors |= ModelIntegrationBehaviors.ReplaceControls
-        attributes = __.DictionaryProxy( desc )
+        attributes = __.types.MappingProxyType( desc )
         return selfclass(
             attributes = attributes, behaviors = behaviors, regex = regex )
 
@@ -266,10 +266,10 @@ class ModelsIntegrator(
         ): theirs[ 'controls' ] = controls
         else: theirs[ 'controls' ].extend( controls )
         _merge_dictionaries_recursive( theirs, ours )
-        return __.DictionaryProxy( theirs )
+        return __.types.MappingProxyType( theirs )
 
 
-class ModelGenera( __.Enum ): # TODO: Python 3.11: StrEnum
+class ModelGenera( __.enum.Enum ): # TODO: Python 3.11: StrEnum
     ''' Available genera for models. '''
 
     # Note: Not including domain-specific classifiers or text completers

--- a/sources/aiwb/providers/interfaces.py
+++ b/sources/aiwb/providers/interfaces.py
@@ -40,7 +40,7 @@ class Provider(
 
     def __str__( self ) -> str: return f"AI provider {self.name!r}"
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def produce_client(
         self,
         auxdata: __.CoreGlobals,
@@ -65,7 +65,7 @@ class Client(
     provider: 'Provider'
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def assert_environment(
         selfclass,
         auxdata: __.CoreGlobals,
@@ -74,7 +74,7 @@ class Client(
         raise NotImplementedError
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def from_descriptor(
         selfclass,
         auxdata: __.CoreGlobals,
@@ -128,7 +128,7 @@ class Client(
         ''' Returns default model available from provider, if it exists. '''
         defaults = getattr( self.attributes.defaults, f"{genus.value}_model" )
         models = await self.survey_models( auxdata = auxdata, genus = genus )
-        models_by_name = __.DictionaryProxy( {
+        models_by_name = __.types.MappingProxyType( {
             model.name: model for model in models } )
         # TODO: Default defaults from provider configuration.
         defaults = defaults or models_by_name
@@ -142,12 +142,12 @@ class Client(
                 f"Could not access default {genus.value} model "
                 f"on provider {self.name!r}." ) from None
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def produce_implement( self ) -> _core.ClientImplement:
         ''' Produces client implement to interact with provider. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def produce_model(
         self,
         genus: _core.ModelGenera,
@@ -157,7 +157,7 @@ class Client(
         ''' Produces model from descriptor. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def survey_models(
         self,
         auxdata: __.CoreGlobals,
@@ -171,7 +171,7 @@ class Client(
         raise NotImplementedError
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def variant( self ) -> _core.ProviderVariants:
         ''' Provider variant. '''
         raise NotImplementedError
@@ -198,7 +198,7 @@ class ControlsProcessor(
         # TODO: Use 'control.name'. (Requires definitions.)
         return frozenset( { control[ 'name' ] for control in self.controls } )
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def nativize_controls(
         self,
         controls: __.cabc.Mapping[ str, __.Control.Instance ],
@@ -217,7 +217,7 @@ class ConversationTokenizer(
 
     # TODO: count_conversation_tokens
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def count_text_tokens( self, text: str ) -> int:
         ''' Counts tokens, using tokenizer for model, in text. '''
         raise NotImplementedError
@@ -225,7 +225,7 @@ class ConversationTokenizer(
     ## v0 Compatibility Functions ##
     # TODO: Remove once cutover to conversation objects is complete.
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def count_conversation_tokens_v0(
         self, messages: __.MessagesCanisters, supplements
     ) -> int:
@@ -241,19 +241,19 @@ class InvocationsProcessor(
 
     model: 'Model'
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def __call__(
         self, request: _core.InvocationRequest
     ) -> __.MessageCanister: # TODO? Return InvocationResult.
         ''' Uses invocable to produce result for conversation. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def nativize_invocable( self, invoker: __.Invoker ) -> __.typx.Any:
         ''' Converts normalized invocable into native tool call. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def nativize_invocables(
         self,
         invokers: __.cabc.Iterable[ __.Invoker ],
@@ -261,7 +261,7 @@ class InvocationsProcessor(
         ''' Converts normalized invocables into native tool calls. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def requests_from_canister(
         self,
         auxdata: __.CoreGlobals, *,
@@ -288,7 +288,7 @@ class MessagesProcessor(
     ## v0 Compatibility Functions ##
     # TODO: Remove once cutover to conversation objects is complete.
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def nativize_messages_v0(
         self,
         canisters: __.MessagesCanisters,
@@ -314,7 +314,7 @@ class Model(
         return f"{self.client} model {self.name!r}"
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def from_descriptor(
         selfclass,
         client: 'Client',
@@ -325,7 +325,7 @@ class Model(
         raise NotImplementedError
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def controls_processor( self ) -> 'ControlsProcessor':
         ''' Controls processor for model. '''
         raise NotImplementedError
@@ -345,7 +345,7 @@ class ModelAttributes(
     controls: __.cabc.Sequence[ __.Control ] = ( )
 
     @classmethod
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def from_descriptor(
         selfclass,
         descriptor: __.cabc.Mapping[ str, __.typx.Any ],
@@ -372,25 +372,25 @@ class ConverserModel(
     ''' Represents AI chat model. '''
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def invocations_processor( self ) -> 'InvocationsProcessor':
         ''' Invocations processor for model. '''
         raise NotImplementedError
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def messages_processor( self ) -> 'MessagesProcessor':
         ''' Conversation messages processor for model. '''
         raise NotImplementedError
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def serde_processor( self ) -> 'ConverserSerdeProcessor':
         ''' (De)serialization processor for model. '''
         raise NotImplementedError
 
     @property
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def tokenizer( self ) -> 'ConversationTokenizer':
         ''' Appropriate tokenizer for conversations. '''
         raise NotImplementedError
@@ -398,7 +398,7 @@ class ConverserModel(
     ## v0 Compatibility Functions ##
     # TODO: Remove once cutover to conversation objects is complete.
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def converse_v0(
         self,
         messages: __.cabc.Sequence[ __.MessageCanister ],
@@ -459,12 +459,12 @@ class ConverserSerdeProcessor(
 
     model: 'ConverserModel'
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def deserialize_data( self, data: str ) -> __.typx.Any:
         ''' Deserializes text in preferred format of model to data. '''
         raise NotImplementedError
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     def serialize_data( self, data: __.typx.Any ) -> str:
         ''' Serializes data to text in preferred format of model. '''
         raise NotImplementedError

--- a/sources/aiwb/providers/preparation.py
+++ b/sources/aiwb/providers/preparation.py
@@ -94,7 +94,7 @@ async def prepare_providers(
     names = frozenset(
         descriptor.get( 'factory', descriptor[ 'name' ] )
         for descriptor in descriptors )
-    preparers = __.DictionaryProxy(
+    preparers = __.types.MappingProxyType(
         {   name: _registries.preparers_registry[ name ]( auxdata )
             for name in names } )
     results = await __.gather_async(

--- a/sources/aiwb/providers/utilities.py
+++ b/sources/aiwb/providers/utilities.py
@@ -47,7 +47,7 @@ async def acquire_provider_configuration(
         configuration[ index_name ] = tuple( sorted(
             configuration[ index_name ] + configurations_,
             key = lambda cfg: cfg[ 'name' ] ) )
-    return __.DictionaryProxy( configuration )
+    return __.types.MappingProxyType( configuration )
 
 
 async def acquire_models_integrators(
@@ -76,7 +76,7 @@ async def acquire_models_integrators(
             #       Catch regex errors and provide proper context.
             integrators[ genus ].append(
                 _core.ModelsIntegrator.from_descriptor( descriptor ) )
-    return __.DictionaryProxy( {
+    return __.types.MappingProxyType( {
         genus: tuple( sequence ) for genus, sequence
         in integrators.items( ) } )
 
@@ -193,7 +193,7 @@ async def memcache_acquire_models_integrators(
         # TODO? async mutex in case of clear-update during access
         cache.clear( )
         cache.update( await acquire_models_integrators( auxdata, name ) )
-    return __.DictionaryProxy( cache )
+    return __.types.MappingProxyType( cache )
 
 
 async def _acquire_configuration(
@@ -224,8 +224,8 @@ async def _acquire_configurations(
     for subdirectory, configuration in zip( subdirectories, configurations ):
         configuration_ = { 'name': subdirectory.name }
         configuration_.update( configuration )
-        configurations_.append( __.DictionaryProxy( configuration_ ) )
-    return __.DictionaryProxy( { index_name: tuple( configurations_ ) } )
+        configurations_.append( __.types.MappingProxyType( configuration_ ) )
+    return __.types.MappingProxyType( { index_name: tuple( configurations_ ) } )
 
 
 def _copy_custom_provider_configurations(

--- a/sources/aiwb/vectorstores/core.py
+++ b/sources/aiwb/vectorstores/core.py
@@ -30,7 +30,7 @@ class Factory(
 ):
     ''' Produces clients. '''
 
-    @__.abstract_member_function
+    @__.abc.abstractmethod
     async def client_from_descriptor(
         self,
         auxdata: __.Globals,
@@ -119,7 +119,7 @@ async def prepare_factories(
     descriptors = descriptors_from_configuration( auxdata )
     names = frozenset(
         descriptor[ 'factory' ] for descriptor in descriptors )
-    preparers_ = __.DictionaryProxy(
+    preparers_ = __.types.MappingProxyType(
         { name: preparers[ name ]( auxdata ) for name in names } )
     results = await __.gather_async(
         *preparers_.values( ), return_exceptions = True )


### PR DESCRIPTION
## Summary
- clean up __ helper to use proper module namespaces
- replace alias usages across the codebase

## Testing
- `ruff check sources tests`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiwb.libcore.locations.adapters.@py_builtins')*

------
https://chatgpt.com/codex/tasks/task_e_688e5ed44628832c9bf4fc91dcc91b5b